### PR TITLE
feat: command to remove collections and resources

### DIFF
--- a/commands/index.js
+++ b/commands/index.js
@@ -2,10 +2,12 @@ import * as exec from './exec.js'
 import * as install from './install.js'
 import * as list from './list.js'
 import * as upload from './upload.js'
+import * as rm from './rm.js'
 
 export const commands = [
   exec,
   install,
   list,
-  upload
+  upload,
+  rm
 ]

--- a/commands/rm.js
+++ b/commands/rm.js
@@ -1,0 +1,144 @@
+import { connect } from '@existdb/node-exist'
+import { readXquery } from '../utility/xq.js'
+
+/**
+ * @typedef { import("node-exist").NodeExist } NodeExist
+ */
+
+/**
+ * the xquery file to execute on the DB
+ */
+const query = readXquery('rm.xq')
+
+const protectedPaths = [
+  '/',
+  '/db',
+  '/db/apps',
+  '/db/system',
+  '/db/system/config',
+  '/db/system/repo',
+  '/db/system/security',
+  '/db/system/security/exist',
+  '/db/system/security/exist/accounts',
+  '/db/system/security/exist/groups'
+]
+
+function guardProtectedPaths (paths) {
+  let foundProtectedPaths = false
+  paths.forEach(path => {
+    if (path === '') {
+      console.error('Cannot remove protected path: /')
+      foundProtectedPaths = true
+      return
+    }
+    if (protectedPaths.includes(path)) {
+      console.error(`Cannot remove protected path: ${path}`)
+      foundProtectedPaths = true
+    }
+  })
+  return foundProtectedPaths
+}
+
+function normalizePath (path) {
+  if (path.endsWith('/')) {
+    return path.substring(0, path.length - 1)
+  }
+  return path
+}
+
+/**
+ * remove collections and resources in exist db
+ * @param {import("@existdb/node-exist").NodeExist} db database client
+ * @param {[String]} paths path to collection in db
+ * @param {RemoveOptions} options command line options
+ * @returns {void}
+ */
+async function rm (db, paths, options) {
+  const { /* glob, dryRun, */ recursive, force } = options
+  const result = await db.queries.readAll(query, {
+    variables: {
+      paths,
+      // glob,
+      // dryRun,
+      recursive,
+      force
+    }
+  })
+  const json = JSON.parse(result.pages.toString())
+  if (json.error) {
+    if (options.debug) {
+      console.error(json.error)
+    }
+    throw Error(json.error.description)
+  }
+  if (options.debug) {
+    console.log(json)
+  }
+
+  json.list.forEach(item => {
+    const { success, path } = item
+    if (success) {
+      console.log('✔︎ ' + path)
+      return
+    }
+    console.error('✘ ' + path + ' - ' + item.error.description)
+  })
+}
+
+export const command = ['remove [options] <paths..>', 'rm', 'delete', 'del']
+export const describe = 'remove collections and resources'
+
+const options = {
+  // g: {
+  //   alias: 'glob',
+  //   describe:
+  //         'remove only collection names and resources whose name match the pattern.',
+  //   type: 'string',
+  //   default: '*'
+  // },
+  // d: {
+  //   alias: 'dry-run',
+  //   describe: 'Only list what would be deleted',
+  //   type: 'boolean'
+  // },
+  r: {
+    alias: 'recursive',
+    describe: 'Descend down the collection tree',
+    type: 'boolean'
+  },
+  f: {
+    alias: 'force',
+    describe: 'Force deletion of non-empty collections',
+    type: 'boolean'
+  }
+}
+
+export const builder = yargs => yargs.options(options)
+
+/**
+ * handle rm command
+ * @param {RemoveOptions} argv options
+ * @returns {Number} exit code
+ */
+export async function handler (argv) {
+  if (argv.help) {
+    return 0
+  }
+
+  const { /* glob, */ paths, connectionOptions } = argv
+
+  // if (glob.includes('**')) {
+  //   console.error('Invalid value for option "glob"; "**" is not supported yet')
+  //   return 1
+  // }
+
+  const normalized = paths.map(normalizePath)
+
+  if (guardProtectedPaths(normalized)) {
+    return 1
+  }
+
+  const db = connect(connectionOptions)
+
+  return rm(db, normalized, argv)
+}

--- a/modules/rm.xq
+++ b/modules/rm.xq
@@ -1,0 +1,84 @@
+xquery version "3.1";
+
+(: required parameter :)
+declare variable $paths as xs:string+ external;
+
+(: options :)
+(: declare variable $glob as xs:string external; :)
+(: declare variable $dryrun as xs:boolean external; :)
+declare variable $recursive as xs:boolean external;
+declare variable $force as xs:boolean external;
+
+declare variable $COLLECTION := "collection";
+declare variable $RESOURCE := "resource";
+
+declare function local:check-path ($path) {
+    if (xmldb:collection-available($path))
+    then $COLLECTION
+    else if (util:binary-doc-available($path) or doc-available($path))
+    then $RESOURCE
+    else error(xs:QName('not_available'), $path || " does not exist")
+};
+
+declare function local:remove($path) {
+    switch(local:check-path($path))
+        case $COLLECTION return
+            if (not($recursive))
+            then error(xs:QName('non_recursive'), $path || " is a collection, but the recursive option is not set")
+            else if (not($force) and exists((xmldb:get-child-resources($path), xmldb:get-child-collections($path))))
+            then error(xs:QName('not_empty'), $path || " is a non-empty collection, but the force option is not set")
+            else (xmldb:remove($path), true())
+        case $RESOURCE return 
+            let $parts := tokenize($path, '/')
+            let $length := count($parts)
+            let $resource := $parts[$length]
+            let $collection := subsequence($parts, 1, $length - 1) => string-join('/')
+            return (xmldb:remove($collection, $resource), true())
+    default return error(xs:QName('unknown_type'), $path || " is of unknown type")
+};
+
+declare function local:safe-remove($path) {
+    try {
+        map {
+            "path": $path,
+            "success": local:remove($path)
+        }
+    }
+    catch * {
+        map {
+            "path": $path,
+            "success": false(),
+            "error": map {
+                "description": $err:description,
+                "code": $err:code
+            }
+        }
+    }
+};
+
+try {
+    serialize(
+        map{
+            "list": array:for-each(
+                array{ $paths }, local:safe-remove#1)
+        },
+        map { "method": "json" }
+    )
+}
+catch * {
+    serialize(
+        map {
+            "error": map {
+                "code": $err:code,
+                "description": $err:description,
+                "value": $err:value,
+                "module": $err:module,
+                "line-number": $err:line-number,
+                "column-number": $err:column-number,
+                "additional": $err:additional,
+                "xquery-stack-trace": $exerr:xquery-stack-trace
+            }
+        },
+        map { "method": "json" }
+    )
+}

--- a/readme.md
+++ b/readme.md
@@ -57,12 +57,11 @@ will output useful information how to use each of the commands.
 
 **Available Commands**
 
-Currently all command line examples from node-exist were ported over:
-
-- `list` list the contents of a collection in eXist-db
-- `upload` upload a files and folders to a collection in eXist-db
-- `install` upload and install a package into eXist-db
-- `execute` execute queries in an eXist-db
+- `list` list the contents of a collection
+- `upload` upload files and folders to a collection
+- `rm` remove collections and resources
+- `install` upload and install a package
+- `execute` query data, run a main module
 
 **Example**
 
@@ -165,4 +164,3 @@ That also works when running the tests (on a remote server maybe or a different 
 ```bash
 dotenv npm test
 ```
-

--- a/spec/tests/list.js
+++ b/spec/tests/list.js
@@ -269,9 +269,9 @@ test('with fixtures uploaded', async (t) => {
 /db/list-test/tests/exec.js
 /db/list-test/tests/install.js
 /db/list-test/tests/list.js
+/db/list-test/tests/rm.js
 /db/list-test/tests/upload.js
 `
-
     st.equal(expectedlines, stdout, stdout)
     st.end()
   })
@@ -294,6 +294,7 @@ test('with fixtures uploaded', async (t) => {
 /db/list-test/tests/upload.js
 /db/list-test/tests/configuration.js
 /db/list-test/tests/exec.js
+/db/list-test/tests/rm.js
 /db/list-test/tests/install.js
 /db/list-test/tests/list.js
 /db/list-test/test.xq

--- a/spec/tests/rm.js
+++ b/spec/tests/rm.js
@@ -1,0 +1,130 @@
+import { test } from 'tape'
+import { run, asAdmin } from '../test.js'
+
+const testCollection = '/db/rm-test'
+
+async function ensureCollectionIsRemoved (t) {
+  const { stderr, stdout } = await run('xst', ['ls', testCollection])
+  if (stdout) { return t.fail(stdout) }
+  t.equal(stderr, `✘ ${testCollection} - ${testCollection} does not exist`)
+}
+
+async function prepare (t) {
+  const query = [
+    'xmldb:create-collection("/db", "rm-test")',
+    `xmldb:create-collection("${testCollection}", "empty-subcollection")`,
+    storeResourceQuery(testCollection, 'b', '"test"'),
+    storeResourceQuery(testCollection, 'a.txt', '"test"'),
+    storeResourceQuery(testCollection, 'a1.txt', '"test"'),
+    storeResourceQuery(testCollection, 'a11.json', '\'{"a":1}\''),
+    storeResourceQuery(testCollection, 'a20.txt', '"test"'),
+    storeResourceQuery(testCollection, 'a22.xml', '<test />'),
+    storeResourceQuery(testCollection, 'index.html', '<html><body>1</body></html>'),
+    storeResourceQuery(testCollection, 'test.xq', '"1"')
+  ].join(',')
+  const { stderr } = await run('xst', ['run', query], asAdmin)
+  if (stderr) { return t.fail(stderr) }
+  t.end()
+}
+
+function storeResourceQuery (collection, fileName, content) {
+  return `xmldb:store("${collection}", "${fileName}", ${content})`
+}
+
+test("calling 'xst rm --help'", async (t) => {
+  const { stderr, stdout } = await run('xst', ['rm', '--help'])
+  if (stderr) { return t.fail(stderr) }
+
+  t.ok(stdout, stdout)
+  t.end()
+})
+
+test('admin cannot remove protected paths', async (t) => {
+  const protectedPaths = [
+    '/',
+    '/db/',
+    '/db/apps',
+    '/db/apps/',
+    '/db/system',
+    '/db/system/',
+    '/db/system/config',
+    '/db/system/repo',
+    '/db/system/security',
+    '/db/system/security/',
+    '/db/system/security/exist',
+    '/db/system/security/exist/accounts',
+    '/db/system/security/exist/groups'
+  ]
+
+  protectedPaths.forEach(p => {
+    t.test(`cannot remove protected path ${p}`, async (st) => {
+      const { stderr, stdout } = await run('xst', ['rm', '-rf', p], asAdmin)
+
+      if (stdout) { return st.fail(stdout) }
+      const path = p !== '/' && p.endsWith('/') ? p.substring(0, p.length - 1) : p
+
+      st.equal(stderr, `Cannot remove protected path: ${path}\n`, stderr)
+      st.end()
+    })
+  })
+})
+
+// reliable tests using fixed set
+test('with test collection', async (t) => {
+  await prepare(t)
+
+  t.test(`cannot remove ${testCollection} as guest`, async (st) => {
+    const { stderr, stdout } = await run('xst', ['rm', '-rf', testCollection])
+
+    if (stdout) { return st.fail(stdout) }
+    st.equal(stderr, `✘ /db/rm-test - Account 'guest' is not allowed to remove collection '${testCollection}'. Cannot remove collection: Account 'guest' is not allowed to remove collection '${testCollection}'\n`, stderr)
+    st.end()
+  })
+
+  t.test(`cannot remove ${testCollection} as admin without -r`, async (st) => {
+    const { stderr, stdout } = await run('xst', ['rm', testCollection], asAdmin)
+
+    if (stdout) { return st.fail(stdout) }
+    st.equal(stderr, `✘ ${testCollection} - ${testCollection} is a collection, but the recursive option is not set\n`, stderr)
+    st.end()
+  })
+
+  t.test(`can remove ${testCollection}/empty-subcollection as admin without -f`, async (st) => {
+    const { stderr, stdout } = await run('xst', ['rm', '-r', testCollection + '/empty-subcollection'], asAdmin)
+
+    if (stderr) { return st.fail(stderr) }
+    st.equal(stdout, `✔︎ ${testCollection}/empty-subcollection\n`, 'empty subcollection was removed')
+    st.end()
+  })
+
+  t.test('cannot remove non-empty collection as admin without -f', async (st) => {
+    const { stderr, stdout } = await run('xst', ['rm', '-r', testCollection], asAdmin)
+
+    if (stdout) { return st.fail(stdout) }
+    st.equal(stderr, `✘ ${testCollection} - ${testCollection} is a non-empty collection, but the force option is not set\n`, stderr)
+    st.end()
+  })
+
+  t.test('can remove several resources', async (st) => {
+    const { stderr, stdout } = await run('xst', ['rm', testCollection + '/a.txt', testCollection + '/a1.txt'], asAdmin)
+
+    if (stderr) { return st.fail(stderr) }
+    const lines = stdout.split('\n')
+    st.equal(lines.length, 3, 'expected number of results')
+    st.equal(lines[0], `✔︎ ${testCollection}/a.txt`, 'first file was removed')
+    st.equal(lines[1], `✔︎ ${testCollection}/a1.txt`, 'second file was removed')
+    st.end()
+  })
+
+  t.test('admin can remove entire collection with -rf', async (st) => {
+    const { stderr, stdout } = await run('xst', ['rm', '-rf', testCollection], asAdmin)
+
+    if (stderr) { return st.fail(stderr) }
+    const lines = stdout.split('\n')
+    st.equal(lines.length, 2, 'expected number of results')
+    st.equal(lines[0], `✔︎ ${testCollection}`, 'test collection was removed')
+    st.end()
+  })
+
+  t.teardown(ensureCollectionIsRemoved)
+})


### PR DESCRIPTION
New command `rm` (`remove`, `delete`, `del`) allows
to remove one or more collections and resources from an eXist-db
instance.

Special paths, like `/db` and `/db/system` are protected and cannot be
deleted as they render the entire database unusable.

Examples:

Remove two resources

```
xst rm /db/temp/a.xml /db/temp/b.xml
```

Remove an entire collection

```
xst rm -rf /db/apps/my-app
```

closes #9 