### PR TITLE
feat: add new command info

### DIFF
--- a/commands/index.js
+++ b/commands/index.js
@@ -1,15 +1,17 @@
 import * as exec from './exec.js'
-import * as pkg from './package/index.js'
-import * as list from './list.js'
-import * as upload from './upload.js'
-import * as rm from './rm.js'
 import * as get from './get.js'
+import * as info from './info.js'
+import * as list from './list.js'
+import * as pkg from './package/index.js'
+import * as rm from './rm.js'
+import * as upload from './upload.js'
 
 export const commands = [
   exec,
-  pkg,
+  get,
+  info,
   list,
-  upload,
+  pkg,
   rm,
-  get
+  upload
 ]

--- a/commands/info.js
+++ b/commands/info.js
@@ -1,0 +1,40 @@
+import { connect } from '@existdb/node-exist'
+import { readXquery } from '../utility/xq.js'
+
+/**
+ * @typedef { import("node-exist").NodeExist } NodeExist
+ */
+
+/**
+ * the xquery file to execute on the DB
+ */
+const query = readXquery('info.xq')
+
+async function info (db, options) {
+  const result = await db.queries.readAll(query, {})
+  const json = JSON.parse(result.pages.toString())
+  if (json.error) {
+    if (options.debug) {
+      console.error(json.error)
+    }
+    throw Error(json.error.description)
+  }
+  console.log(`Build: ${json.db.name}-${json.db.version} (${json.db.git})`)
+  console.log(`Java: ${json.java.version} (${json.java.vendor})`)
+  console.log(`OS: ${json.os.name} ${json.os.version} (${json.os.arch})`)
+}
+
+export const command = ['info']
+export const describe = 'gather information on connected the instance'
+
+/**
+ * handle info command
+ * @returns {Number} exit code
+ */
+export async function handler (argv) {
+  if (argv.help) {
+    return 0
+  }
+  const { connectionOptions } = argv
+  return info(connect(connectionOptions), argv)
+}

--- a/modules/info.xq
+++ b/modules/info.xq
@@ -1,0 +1,44 @@
+xquery version "3.1";
+
+declare function local:info () as map(*) {
+    map {
+        "db": map {
+            "name": system:get-product-name(),
+            "version": system:get-version(),
+            "git": system:get-revision()
+        },
+        "java": map {
+            "vendor": util:system-property("java.vendor"),
+            "version": util:system-property("java.version")
+        },
+        "os": map {
+            "name": util:system-property("os.name"),
+            "version": util:system-property("os.version"),
+            "arch": util:system-property("os.arch")
+        }
+    }
+};
+
+try {
+    serialize(
+        local:info(),
+        map { "method": "json" })
+}
+catch * {
+    let $error :=
+        map {
+            "code": $err:code,
+            "description": $err:description,
+            "value": $err:value,
+            "module": $err:module,
+            "line-number": $err:line-number,
+            "column-number": $err:column-number,
+            "additional": $err:additional,
+            "xquery-stack-trace": $exerr:xquery-stack-trace
+        }
+
+    return
+        serialize(
+            map { "error": $error },
+            map { "method": "json" })
+}

--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,7 @@ xst <command> --help
 
 **Available Commands**
 
+- `info` show system information of the connected database
 - `list` list the contents of a collection
 - `upload` upload files and folders to a collection
 - `get` download a collection or resource to the filesystem

--- a/spec/tests/info.js
+++ b/spec/tests/info.js
@@ -1,0 +1,14 @@
+import { test } from 'tape'
+import { run, asAdmin } from '../test.js'
+
+test("calling 'xst info'", async (t) => {
+  const { stderr, stdout } = await run('xst', ['info'], asAdmin)
+  if (stderr) { return t.fail(stderr) }
+
+  const lines = stdout.split('\n')
+  t.equal(lines.length, 4, 'outputs four lines')
+  t.ok(lines[0].startsWith('Build: '), 'has build info')
+  t.ok(lines[1].startsWith('Java: '), 'has Java info')
+  t.ok(lines[2].startsWith('OS: '), 'has OS info')
+  t.end()
+})

--- a/spec/tests/list.js
+++ b/spec/tests/list.js
@@ -268,6 +268,7 @@ test('with fixtures uploaded', async (t) => {
 /db/list-test/tests/configuration.js
 /db/list-test/tests/exec.js
 /db/list-test/tests/get.js
+/db/list-test/tests/info.js
 /db/list-test/tests/install.js
 /db/list-test/tests/list.js
 /db/list-test/tests/rm.js
@@ -291,6 +292,7 @@ test('with fixtures uploaded', async (t) => {
 /db/list-test/fixtures/broken-test-app.xar
 /db/list-test/fixtures/test.xml
 /db/list-test/tests
+/db/list-test/tests/info.js
 /db/list-test/tests/cli.js
 /db/list-test/tests/upload.js
 /db/list-test/tests/configuration.js


### PR DESCRIPTION
`xst info` will gather useful system information.
The output can directly be used to add to eXist issues.

Example output:
```
❯ xst info
Build: eXist-6.1.0-SNAPSHOT (89109f644c19482a0f48f7d47619589ba2f14092)
Java: 1.8.0_352 (Azul Systems, Inc.)
OS: Mac OS X 12.6.2 (aarch64)
```