### PR TITLE
feat(package): list packages

### DIFF
--- a/commands/list.js
+++ b/commands/list.js
@@ -2,6 +2,7 @@ import { connect, getMimeType } from '@existdb/node-exist'
 import { ct } from '../utility/console.js'
 import { readXquery } from '../utility/xq.js'
 import { getDateFormatter } from '../utility/colored-date.js'
+import { multiSort } from '../utility/sorter.js'
 
 /**
  * @typedef { import("node-exist").NodeExist } NodeExist
@@ -45,7 +46,7 @@ import { getDateFormatter } from '../utility/colored-date.js'
  * @typedef {(item:ListResultItem, indent:String, last:Boolean, level:Number) => void} TreeItemRenderer
  */
 /**
- * @typedef {(itemA:ListResultItem, itemB:ListResultItem) => Number} ItemSorter
+ * @typedef { import('../utility/sorter.js').ItemSorter} ItemSorter
  */
 
 /**
@@ -478,16 +479,7 @@ function getSorter (options) {
     sorters.push(sortByType)
   }
   sorters.push(sortByName)
-  return (a, b) => {
-    let v = 0
-    let i = 0
-    let sf = sorters[i]
-    while (v === 0 && sf) {
-      v = reverse ? sf(b, a) : sf(a, b)
-      sf = sorters[++i]
-    }
-    return v
-  }
+  return (a, b) => multiSort(a, b, sorters, reverse)
 }
 
 // list

--- a/commands/list.js
+++ b/commands/list.js
@@ -441,7 +441,7 @@ function getGroupFormatter (options, paddings) {
 
 /**
  * get item rendering function
- * @param {Object} options given options
+ * @param {ListOptions} options given options
  * @param {BlockFormatter[]} blocks block rendering functions
  * @returns {ItemRenderer|TreeItemRenderer} rendering function
  */

--- a/commands/list.js
+++ b/commands/list.js
@@ -1,6 +1,7 @@
 import { connect, getMimeType } from '@existdb/node-exist'
 import { ct } from '../utility/console.js'
 import { readXquery } from '../utility/xq.js'
+import { getDateFormatter } from '../utility/colored-date.js'
 
 /**
  * @typedef { import("node-exist").NodeExist } NodeExist
@@ -99,78 +100,6 @@ function padReducer (paddings, next) {
  */
 function getPaddings (list) {
   return list.reduce(padReducer, initialPaddings)
-}
-
-// time
-
-const timeFormat = {
-  hour12: false,
-  hour: '2-digit',
-  minute: '2-digit'
-}
-const dateFormat = {
-  month: 'short'
-}
-
-const now = new Date()
-const currentYear = now.getFullYear()
-const nowMs = now.getTime()
-
-/**
- * format date to short representation
- * @param {Date} date
- * @returns {String} formatted date
- */
-function formatDateShort (date) {
-  const year = date.getFullYear()
-  const month = date.toLocaleDateString('iso', dateFormat)
-  const day = date.getDate().toString().padStart(3)
-  if (year < currentYear) {
-    return month + day + year.toString().padStart(6)
-  }
-  const time = date.toLocaleTimeString('iso', timeFormat).padStart(6)
-  return month + day + time
-}
-
-const quarterHour = 900000
-const hour = 3600000
-const day = 86400000
-const month = 2592000000
-const quarterYear = 7776000000
-const year = 31104000000
-const steps = [year, quarterYear, month, day, hour, quarterHour]
-const greens = [70, 34, 40, 114, 84, 156]
-
-/**
- * receive a color from the greens palette to color a date
- * relative to the current date
- * @param {Date} date the date to get the color for
- * @returns {Number} xterm256color
- */
-function colorForDate (date) {
-  const msSince = nowMs - date.getTime()
-  const index = steps.reduce((acc, next, step) => (msSince < next ? step : acc), 0)
-  return greens[index]
-}
-
-/**
- * get date formatting function
- * @param {ListOptions} options list rendering options
- * @returns {(item:ListResultItem) => String} date formatting function
- */
-function getDateFormatter (options) {
-  let formatter = formatDateShort
-  if (options.date === 'iso') {
-    formatter = (date) => date.toISOString()
-  }
-  if (options.color) {
-    return (item) => {
-      const date = new Date(item.modified)
-      const formattedDate = formatter(date)
-      return ct(formattedDate, colorForDate(date))
-    }
-  }
-  return (item) => formatter(new Date(item.modified))
 }
 
 // tree
@@ -663,7 +592,7 @@ async function ls (db, collection, options) {
     blocks.push(getOwnerFormatter(options, paddings))
     blocks.push(getGroupFormatter(options, paddings))
     blocks.push(getSizeFormatter(options, paddings))
-    blocks.push(getDateFormatter(options, paddings))
+    blocks.push(getDateFormatter(options, 'modified'))
   }
 
   if (tree) {

--- a/commands/package/index.js
+++ b/commands/package/index.js
@@ -1,4 +1,10 @@
 import * as install from './install.js'
+import * as list from './list.js'
+
+const commands = [
+  install,
+  list
+]
 
 export const command = ['package <command>', 'pkg']
 export const describe = 'do something with packages'
@@ -8,5 +14,5 @@ export async function handler (argv) {
   }
 }
 export const builder = function (yargs) {
-  return yargs.command([install]).recommendCommands()
+  return yargs.command(commands).recommendCommands()
 }

--- a/commands/package/list.js
+++ b/commands/package/list.js
@@ -1,0 +1,778 @@
+import { connect } from '@existdb/node-exist'
+import { ct } from '../../utility/console.js'
+import { readXquery } from '../../utility/xq.js'
+
+/**
+ * @typedef {Object} ListOptions
+ * @prop {Boolean} color color output or not
+ * @prop {Boolean} extended show all info per entry in list
+ * @prop {Boolean} libraries only show collections
+ * @prop {Boolean} applications only show collections
+ * @prop {Boolean} dependencies only show collections
+ * @prop {Boolean} fullUri use package URIs instead of abbreviations
+ * @prop {"short"|"iso"|false} date show installation date
+ * @prop {Object} connectionOptions DB connection options
+ */
+
+/**
+ * @typedef {Object} VersionedItem
+ * @prop {String} name package URI
+ * @prop {String} min SemVer version
+ * @prop {String} max SemVer version
+ * @prop {String} template SemVer version template
+ * @prop {String[]} exact list of versions
+ */
+
+/**
+ * @typedef {Object} Components
+ * @prop {String[]} xslt exported XSLT module
+ * @prop {String[]} xquery exported XQuery modules
+ * @prop {String[]} xproc exported XProc scripts
+ * @prop {String[]} xsd exported XSDs
+ * @prop {String[]} rng exported RelaxNG schemas
+ * @prop {String[]} schematron exported schematron schemas
+ * @prop {String[]} nvdl exported NVDLs
+ * @prop {String[]} resource exported resources
+ */
+
+/**
+ * @typedef {Object} ListResultItem
+ * @prop {String} date the iso dateTime string when the package was installed
+ * @prop {VersionedItem} processor the declared XPath, XQuery, XSLT processor dependency
+ * @prop {Components} components the declared package dependencies
+ * @prop {String} website website of the package
+ * @prop {String} abbrev abbreviated name of the package
+ * @prop {String} target the target collection
+ * @prop {String} description one or two sentences explaining the purpose of the package
+ * @prop {"application"|"library"} type the type of the item
+ * @prop {String} uri the package URI
+ * @prop {String[]} authors the authors of the package
+ * @prop {String} version the installed package version (mostly SemVer)
+ * @prop {String} title the title of the package
+ * @prop {VersionedItem[]} dependencies the declared package dependencies
+ * @prop {String} license the license of the package (free text)
+ */
+
+/**
+ * @typedef {(item:ListResultItem) => void} ItemFormatter
+ */
+/**
+ * @typedef {(item:ListResultItem) => String} BlockFormatter
+ */
+/**
+ * @typedef {(item:ListResultItem) => void} ItemRenderer
+ */
+/**
+ * @typedef {(itemA:ListResultItem, itemB:ListResultItem) => Number} ItemSorter
+ */
+/**
+ * @typedef {(item:ListResultItem) => Boolean} ItemFilter
+ */
+
+const query = readXquery('list-packages.xq')
+
+// tree
+
+// const FILL = '│   '
+const ITEM = '├── '
+const LAST = '└── '
+// const EMPTY = '    '
+
+/**
+ * Get maximum needed paddings for owner, group and size (in bytes)
+ * @param {BlockPaddings} paddings
+ * @param {ListResultItem} next
+ * @returns {BlockPaddings} actual paddings
+ */
+function padReducer (paddings, next) {
+  if (paddings.get('abbrev') < next.abbrev.length) {
+    paddings.set('abbrev', next.abbrev.length)
+  }
+  if (paddings.get('uri') < next.uri.length) {
+    paddings.set('uri', next.uri.length)
+  }
+  if (paddings.get('padVersion') < next.version.length) {
+    paddings.set('padVersion', next.version.length)
+  }
+  if (paddings.get('padAuthor') < next.authors[0].length) {
+    paddings.set('padAuthor', next.authors[0].length)
+  }
+  if (paddings.get('padLicense') < next.license.length) {
+    paddings.set('padLicense', next.license.length)
+  }
+  return paddings
+}
+
+/**
+ * @typedef {Map<String, Number>} BlockPaddings
+ */
+const initialPaddings = new Map([
+  ['abbrev', 0],
+  ['uri', 0],
+  ['padVersion', 3],
+  ['padAuthor', 0],
+  ['padLicense', 0]
+])
+
+/**
+ * get block paddings for list
+ * @param {ListResultItem[]} list of result items
+ * @returns {BlockPaddings} block paddings for list
+ */
+function getPaddings (list) {
+  return list.reduce(padReducer, initialPaddings)
+}
+
+/**
+ * Is pkg a library?
+ * @param {ListResultItem} pkg package to check
+ * @returns {Boolean} whether this is a library or not
+ */
+function isLibrary (pkg) {
+  return pkg.type === 'library'
+}
+
+/**
+ * Get Item filter
+ * @param {ListOptions} options the options
+ * @returns {ItemFilter} the filter
+ */
+function getFilter (options) {
+  if (options.lib) {
+    return pkg => isLibrary(pkg)
+  }
+  if (options.app) {
+    return pkg => !isLibrary(pkg)
+  }
+  return _ => true
+}
+
+/**
+ * Display the Item identifier colored
+ * @param {ListResultItem} pkg the item
+ * @param {"abbrev"|"uri"} prop the identifier to show
+ * @returns {String} the colored terminal output
+ */
+function coloredDisplay (pkg, prop) {
+  return isLibrary(pkg)
+    ? ct(pkg[prop], 'FgBlue')
+    : ct(pkg[prop], 'FgCyan')
+}
+
+/**
+ * Display the item identifier
+ * @param {ListResultItem} pkg the item
+ * @param {"abbrev"|"uri"} prop the identifier to show
+ * @returns {String} the terminal output
+ */
+function display (pkg, prop) {
+  return pkg[prop]
+}
+
+/**
+ * pad the given prop to the appropriate length
+ * @param {ListResultItem} pkg the item
+ * @param {BlockPaddings} paddings the paddings
+ * @param {"abbrev"|"uri"} prop the prop to pad
+ * @returns {ListResultItem} with padded prop
+ */
+function padProp (pkg, paddings, prop) {
+  pkg[prop] = pkg[prop].padEnd(paddings.get(prop))
+  return pkg
+}
+
+/**
+ * get the formatter for the main item identifier
+ * @param {ListOptions} options the options
+ * @param {BlockPaddings} paddings the paddings
+ * @returns {BlockFormatter} format main identifier
+ */
+function getAbbrevFormatter (options, paddings) {
+  const prop = options.fullUri ? 'uri' : 'abbrev'
+  if (options.color) {
+    return pkg => coloredDisplay(padProp(pkg, paddings, prop), prop)
+  }
+  return pkg => display(padProp(pkg, paddings, prop), prop)
+}
+
+/**
+ * get the version block formatter
+ * @param {ListOptions} options the options
+ * @param {BlockPaddings} paddings the paddings
+ * @returns {BlockFormatter} format version block
+ */
+function getVersionFormatter (options, paddings) {
+  return pkg => pkg.version.padEnd(paddings.get('padVersion'))
+}
+
+/**
+ * output a colored label in extended view
+ * @param {String} label the label
+ * @returns {String} colored terminal output
+ */
+function coloredLabel (label) {
+  return ct(label, 'FgGreen', 'Dim')
+}
+
+/**
+ * output authors with quantified label
+ * @param {ListOptions} options the options
+ * @returns {BlockFormatter} author formatter
+ */
+function getAuthorsFormatter (options) {
+  if (options.color) {
+    return pkg => coloredLabel(`Author${pkg.authors.length > 1 ? 's' : ''}: `) + pkg.authors.join(' ')
+  }
+  return pkg => `Author${pkg.authors.length > 1 ? 's' : ''}: ` + pkg.authors.join(' ')
+}
+
+/**
+ * shorten well-known processor URI
+ * @param {String} name processor URI
+ * @returns {String|"existdb"} maybe shortened name
+ */
+function processorName (name) {
+  return name === 'http://exist-db.org' ? 'existdb' : name
+}
+
+/**
+ * get processor block formatter
+ * @param {ListOptions} options the options
+ * @returns {BlockFormatter} the formatter
+ */
+function getProcessorFormatter (options) {
+  if (options.color) {
+    return function (pkg) {
+      if (!pkg.processor.uri) {
+        return coloredLabel('Processor: ') + 'any'
+      }
+      return coloredLabel('Processor: ') + processorName(pkg.processor.uri) + ' ' + ct(formatVersion(pkg.processor), 'FgYellow')
+    }
+  }
+  return function (pkg) {
+    if (!pkg.processor.name) {
+      return 'Processor: any'
+    }
+    return 'Processor: ' + processorName(pkg.processor.name) + ' ' + formatVersion(pkg.processor)
+  }
+}
+
+/**
+ * generic extended block formatter
+ * @param {ListOptions} options the options
+ * @param {String} label the label
+ * @param {String} prop the property
+ * @returns {BlockFormatter} the formatter
+ */
+function getLabelFormatter (options, label, prop) {
+  if (options.color) {
+    return pkg => (pkg[prop] ? coloredLabel(label + ': ') + pkg[prop] : null)
+  }
+  return pkg => (pkg[prop] ? label + ': ' + pkg[prop] : null)
+}
+
+/**
+ * helper function to render version ranges and templates
+ * @param {VersionedItem} versionedItem the versioned item
+ * @returns {String} the formatted version
+ */
+function formatVersion (versionedItem) {
+  if (versionedItem.exact.length) {
+    return versionedItem.exact.join(',')
+  }
+  if (versionedItem.template) {
+    const parts = versionedItem.template.split('.')
+    switch (parts.length) {
+      case 3: return versionedItem.template
+      case 2: return versionedItem.template + '.x'
+      default: return versionedItem.template + '.x.x'
+    }
+  }
+  if (versionedItem.min && versionedItem.max) {
+    return versionedItem.min + '-' + versionedItem.max
+  }
+  if (versionedItem.min) {
+    return '>=' + versionedItem.min
+  }
+  if (versionedItem.max) {
+    return '<=' + versionedItem.max
+  }
+  return '*'
+}
+
+/**
+ * convert URIs to corresponding abbrev
+ * @param {Map<String, String>} uri2abbrev the mapping
+ * @param {String} uri the package URI
+ * @returns {String} the abbrev
+ */
+function toAbbrev (uri2abbrev, uri) {
+  return uri2abbrev.get(uri)
+}
+
+/**
+ * return given URI unchanged (ID transform)
+ * @param {String} uri the package URI
+ * @returns {String} the package URI
+ */
+function uri (uri) {
+  return uri
+}
+
+/**
+ * get list item prefix according to position in list
+ * @param {Number} index current index
+ * @param {Array} array list of dependencies
+ * @returns {String} prefix for dependency list item
+ */
+function isLast (index, array) {
+  return index === array.length - 1 ? LAST : ITEM
+}
+
+/**
+ * format dependency list item
+ * @param {Function} fmt uri formatter function
+ * @param {Object} dependency dependency list item
+ * @param {Number} index current items index
+ * @param {Array} array list of all dependencies
+ * @returns {String} terminal output
+ */
+function formatDependency (fmt, dependency, index, array) {
+  return isLast(index, array) +
+    fmt(dependency.uri) + ' ' +
+    formatVersion(dependency)
+}
+
+/**
+ * format and color dependency list item
+ * @param {Function} fmt uri formatter function
+ * @param {Object} dependency dependency list item
+ * @param {Number} index current items index
+ * @param {Array} array list of all dependencies
+ * @returns {String} colored terminal output
+ */
+function formatDependencyColored (fmt, dependency, index, array) {
+  return isLast(index, array) +
+    fmt(dependency.uri) + ' ' +
+    ct(formatVersion(dependency), 'FgYellow')
+}
+
+/**
+ * ouput list of formatted dependencies
+ * @param {Function} fmt uri formatter function
+ * @param {ListResultItem} pkg the item
+ * @returns {String} formatted dependencies
+ */
+function formatDependencies (fmt, pkg) {
+  if (!pkg.dependencies.length) {
+    return LAST + '(no dependency)'
+  }
+  return pkg.dependencies.map(formatDependency.bind(null, fmt)).join('\n')
+}
+
+/**
+ * ouput list of formatted and colored dependencies
+ * @param {Function} fmt uri formatter function
+ * @param {ListResultItem} pkg the item
+ * @returns {String} formatted and colored dependencies
+ */
+function formatDependenciesColored (fmt, pkg) {
+  if (!pkg.dependencies.length) {
+    return LAST + ct('(no dependency)', 'FgWhite', 'Dim')
+  }
+  return pkg.dependencies.map(formatDependencyColored.bind(null, fmt)).join('\n')
+}
+
+/**
+ * get depency list formatter
+ * @param {ListResultItem[]} list the list of items
+ * @param {ListOptions} options the options
+ * @returns {BlockFormatter} extended block formatter
+ */
+function getDependenciesFormatter (list, options) {
+  let fmt = uri
+  if (!options.fullUri) {
+    fmt = toAbbrev.bind(null, new Map(list.map(pkg => [pkg.uri, pkg.abbrev])))
+  }
+  if (options.color) {
+    return formatDependenciesColored.bind(null, fmt)
+  }
+  return formatDependencies.bind(null, fmt)
+}
+
+/**
+ * render components
+ * @param {ListResultItem} pkg the item
+ * @returns {String[][]} list of components
+ */
+function gatherComponents (pkg) {
+  const components = []
+  for (const key in pkg.components) {
+    if (pkg.components[key].length === 0) { continue }
+    if (pkg.components[key].length === 1) {
+      components.push([key, ' ' + pkg.components[key]])
+      continue
+    }
+    components.push([key, '\n    ' + pkg.components[key].join('\n    ')])
+  }
+  return components
+}
+
+/**
+ * colored component block formatter
+ * @param {ListResultItem} pkg the item
+ * @returns {String} colored terminal output
+ */
+function formatComponentsColored (pkg) {
+  if (!isLibrary(pkg)) { return null }
+
+  const components = gatherComponents(pkg)
+  if (components.length) {
+    return coloredLabel('Components:\n') + components.map(a => '  ' + coloredLabel(a[0] + ':') + a[1]).join('\n')
+  }
+  return coloredLabel('Components:') + ct('none', 'FgRed', 'Bright')
+}
+
+/**
+ * component block formatter
+ * @param {ListResultItem} pkg the item
+ * @returns {String} terminal output
+ */
+function formatComponents (pkg) {
+  if (!isLibrary(pkg)) { return null }
+
+  const components = gatherComponents(pkg)
+  if (components.length) {
+    return 'Components:\n' + components.map(a => '  ' + a[0] + ':' + a[1]).join('\n')
+  }
+  return 'Components: none'
+}
+
+/**
+ * get the component block formatter
+ * @param {ListOptions} options the options
+ * @returns {BlockFormatter} the component block formatter
+ */
+function getComponentsFormatter (options) {
+  if (options.color) {
+    return formatComponentsColored
+  }
+  return formatComponents
+}
+
+const timeFormat = {
+  hour12: false,
+  hour: '2-digit',
+  minute: '2-digit'
+}
+const dateFormat = {
+  month: 'short'
+}
+
+const now = new Date()
+const currentYear = now.getFullYear()
+const nowMs = now.getTime()
+
+/**
+ * format date to short representation
+ * @param {Date} date
+ * @returns {String} formatted date
+ */
+function formatDateShort (date) {
+  const year = date.getFullYear()
+  const month = date.toLocaleDateString('iso', dateFormat)
+  const day = date.getDate().toString().padStart(3)
+  if (year < currentYear) {
+    return month + day + year.toString().padStart(6)
+  }
+  const time = date.toLocaleTimeString('iso', timeFormat).padStart(6)
+  return month + day + time
+}
+
+const quarterHour = 900000
+const hour = 3600000
+const day = 86400000
+const month = 2592000000
+const quarterYear = 7776000000
+const year = 31104000000
+const steps = [year, quarterYear, month, day, hour, quarterHour]
+const greens = [70, 34, 40, 114, 84, 156]
+
+/**
+ * receive a color from the greens palette to color a date
+ * relative to the current date
+ * @param {Date} date the date to get the color for
+ * @returns {Number} xterm256color
+ */
+function colorForDate (date) {
+  const msSince = nowMs - date.getTime()
+  const index = steps.reduce((acc, next, step) => (msSince < next ? step : acc), 0)
+  return greens[index]
+}
+
+/**
+ * get date formatting function
+ * @param {ListOptions} options list rendering options
+ * @returns {(item:ListResultItem) => String} date formatting function
+ */
+function getDateFormatter (options) {
+  let formatter = formatDateShort
+  if (options.date === 'iso') {
+    formatter = (date) => date.toISOString()
+  }
+  if (options.color) {
+    return (item) => {
+      const date = new Date(item.date)
+      const formattedDate = formatter(date)
+      return ct(formattedDate, colorForDate(date))
+    }
+  }
+  return (item) => formatter(new Date(item.date))
+}
+
+/**
+ * Get the item formatting function
+ * @param {ListResultItem[]} list the list
+ * @param {ListOptions} options the options
+ * @returns {ItemFormatter} the formatter
+ */
+function getItemFormatter (list, options) {
+  const { versions, date, extended, dependencies, color, fullUri } = options
+  if (!versions && !date && !extended && !dependencies) {
+    const pkgFmt = color ? coloredDisplay : display
+    const prop = fullUri ? 'uri' : 'abbrev'
+    return pkg => console.log(pkgFmt(pkg, prop))
+  }
+
+  const paddings = getPaddings(list)
+  const blocks = []
+  blocks.push(getAbbrevFormatter(options, paddings))
+  if (versions) {
+    blocks.push(getVersionFormatter(options, paddings))
+  }
+  if (date) {
+    blocks.push(getDateFormatter(options))
+  }
+
+  const extBlocks = []
+  if (dependencies) {
+    extBlocks.push(getDependenciesFormatter(list, options))
+  }
+
+  if (extended) {
+    extBlocks.push(getLabelFormatter(options, 'Title', 'title'))
+    extBlocks.push(getLabelFormatter(options, 'URI', 'uri'))
+    extBlocks.push(getAuthorsFormatter(options))
+    extBlocks.push(getLabelFormatter(options, 'Description', 'description'))
+    extBlocks.push(getLabelFormatter(options, 'Website', 'website'))
+    extBlocks.push(getLabelFormatter(options, 'Version', 'version'))
+    extBlocks.push(getLabelFormatter(options, 'Installed', 'date'))
+    extBlocks.push(getProcessorFormatter(options))
+    extBlocks.push(getLabelFormatter(options, 'Target', 'target'))
+    extBlocks.push(getLabelFormatter(options, 'Type', 'type'))
+    extBlocks.push(getLabelFormatter(options, 'License', 'license'))
+    // show exports for libraries
+    extBlocks.push(getComponentsFormatter(options))
+    return function (pkg) {
+      const output = blocks.map(bf => bf(pkg))
+      console.log(output.join(' '))
+      extBlocks.forEach(bf => {
+        const res = bf(pkg)
+        if (res === null) { return }
+        console.log(res)
+      })
+      console.log()
+    }
+  }
+
+  return function (pkg) {
+    const output = blocks.map(bf => bf(pkg))
+    console.log(output.join(' '))
+    extBlocks.forEach(bf => console.log(bf(pkg)))
+  }
+}
+
+/**
+ * sort items by their name in alphabetical order
+ * @param {ListResultItem} itemA
+ * @param {ListResultItem} itemB
+ * @returns {Number} sort direction
+ */
+function sortByName (itemA, itemB) {
+  return itemA.abbrev.localeCompare(itemB.abbrev)
+}
+
+/**
+ * sort items by their type
+ * @param {ListResultItem} itemA
+ * @param {ListResultItem} itemB
+ * @returns {Number} sort direction
+ */
+function sortByType (itemA, itemB) {
+  const a = isLibrary(itemA)
+  const b = isLibrary(itemB)
+  if (a === b) return 0
+  return a ? 1 : -1
+}
+
+/**
+ * get the modified date as milliseconds since epoch start
+ * @param {ListResultItem} item result item
+ * @returns {Number} milliseconds since epoch start
+ */
+function getMillis (dateString) {
+  const d = new Date(dateString)
+  return d.getTime()
+}
+
+/**
+ * sort items by their installation time
+ * @param {ListResultItem} itemA
+ * @param {ListResultItem} itemB
+ * @returns {Number} sort direction
+ */
+function sortByTime (itemA, itemB) {
+  const mtA = getMillis(itemA.date)
+  const mtB = getMillis(itemB.date)
+  return mtB - mtA
+}
+
+/**
+ * get sorting function
+ * @param {ListOptions} options given options
+ * @returns {ItemSorter} sorting function
+ */
+function getSorter (options) {
+  const { reverse, typesort, timesort } = options
+  const sorters = []
+  if (typesort) {
+    sorters.push(sortByType)
+  }
+  if (timesort) {
+    sorters.push(sortByTime)
+  }
+  sorters.push(sortByName)
+  return (a, b) => {
+    let v = 0
+    let i = 0
+    let sf = sorters[i]
+    while (v === 0 && sf) {
+      v = reverse ? sf(b, a) : sf(a, b)
+      sf = sorters[++i]
+    }
+    return v
+  }
+}
+
+/**
+ * list installed packages raw, colored, sorted and/or filtered
+ * @param {NodeExist} db database connection
+ * @param {ListOptions} options the options
+ * @returns {Number} the exit code
+ */
+async function listPackages (db, options) {
+  const result = await db.queries.readAll(query, {})
+  const raw = result.pages.toString()
+  if (options.raw) {
+    return console.log(raw)
+  }
+
+  const json = JSON.parse(raw)
+  // if (json.error) {
+  //   if (options.debug) {
+  //     console.error(json.error)
+  //   }
+  //   throw Error(json.error.description)
+  // }
+  const filteredPkgs = json.packages.filter(getFilter(options))
+  filteredPkgs
+    .sort(getSorter(options))
+    .forEach(getItemFormatter(json.packages, options))
+  return 0
+}
+
+export const command = ['list [options]', 'ls']
+export const describe = 'List installed packages'
+
+const options = {
+  G: {
+    alias: 'color',
+    describe: 'Color the output',
+    default: false,
+    type: 'boolean'
+  },
+  V: {
+    alias: 'versions',
+    describe: 'Display installed version',
+    default: false,
+    type: 'boolean'
+  },
+  e: {
+    alias: 'extended',
+    describe: 'Display more information for each item',
+    default: false,
+    type: 'boolean'
+  },
+  t: {
+    alias: 'typesort',
+    describe: 'Sort by type',
+    type: 'boolean',
+    default: false
+  },
+  T: {
+    alias: 'timesort',
+    describe: 'Sort by installation date',
+    type: 'boolean',
+    default: false
+  },
+  r: {
+    alias: 'reverse',
+    describe: 'Reverse the order of the sort',
+    type: 'boolean'
+  },
+  a: {
+    alias: ['app', 'applications'],
+    describe: 'Only list installed application packages',
+    type: 'boolean'
+  },
+  l: {
+    alias: ['lib', 'libraries'],
+    describe: 'Only list installed library packages',
+    type: 'boolean'
+  },
+  date: {
+    describe: 'Show installation date',
+    choices: ['short', 'iso'],
+    coerce: v => v === true ? 'short' : v
+  },
+  D: {
+    alias: ['deps', 'dependencies'],
+    describe: 'Show package dependencies',
+    type: 'boolean',
+    default: false
+  },
+  fullUri: {
+    describe: 'Use full URIs for display',
+    type: 'boolean',
+    default: false
+  },
+  raw: {
+    describe: 'Return raw JSON data from query',
+    type: 'boolean',
+    default: false
+  }
+}
+
+export const builder = yargs => {
+  return yargs.options(options)
+    .conflicts('a', 'l')
+}
+
+export async function handler (argv) {
+  if (argv.help) {
+    return 0
+  }
+
+  const db = connect(argv.connectionOptions)
+  return await listPackages(db, argv)
+}

--- a/modules/list-packages.xq
+++ b/modules/list-packages.xq
@@ -1,0 +1,113 @@
+xquery version "3.1";
+
+declare namespace expath="http://expath.org/ns/pkg";
+declare namespace repo="http://exist-db.org/xquery/repo";
+
+declare
+function local:get-package-meta(
+    $package-uri as xs:string, $resource as xs:string
+) as document-node() {
+    try {
+        repo:get-resource($package-uri, $resource)
+        => util:binary-to-string() 
+        => parse-xml()
+    }
+    catch * {
+        ()
+    }
+};
+
+declare
+function local:dependency ($dep as element(expath:dependency)?) as map(*) {
+    map {
+        "uri": ($dep/(@package|@processor))[1]/string(),
+        "min": $dep/@semver-min/string(),
+        "max": $dep/@semver-max/string(),
+        "template": $dep/@semver/string(),
+        "exact": array { tokenize($dep/@versions, ' ') }
+    }
+};
+
+declare
+function local:component($component as element()) as xs:string {
+    $component/(expath:namespace|expath:import-uri|expath:public-uri)/string()
+};
+
+declare
+function local:expath($package-uri as xs:string) as map(*) {
+    let $expath := local:get-package-meta($package-uri, "expath-pkg.xml")
+
+    return
+        map {
+            "uri": $expath//@name,
+            "abbrev": $expath//@abbrev/string(),
+            "version": $expath//expath:package/@version/string(),
+            "title": $expath//expath:title/text(),
+            "processor": local:dependency($expath//expath:dependency[@processor]),
+            "dependencies": array {
+                for-each($expath//expath:dependency[@package],
+                    local:dependency#1)
+            },
+            "components": map {
+                "xslt": array { for-each($expath//expath:xslt, local:component#1 ) },
+                "xquery": array { for-each($expath//expath:xquery, local:component#1 ) },
+                "xproc": array { for-each($expath//expath:xproc, local:component#1 ) },
+                "xsd": array { for-each($expath//expath:xsd, local:component#1 ) },
+                "rng": array { for-each($expath//expath:rng, local:component#1 ) },
+                "schematron": array { for-each($expath//expath:schematron, local:component#1 ) },
+                "nvdl": array { for-each($expath//expath:nvdl, local:component#1 ) },
+                "resource": array { for-each($expath//expath:resource, local:component#1 ) }
+                (: "dtd": array { for-each($expath//expath:dtd, local:component#1 ) } :)
+            }
+            (: ,"expath": $expath :)
+        }
+};
+
+declare
+function local:repo($package-uri as xs:string) as map(*) {
+    let $repo := local:get-package-meta($package-uri, "repo.xml")
+
+    return
+        map {
+            "website": $repo//repo:website/text(),
+            "description": $repo//repo:description/text(),
+            "license": $repo//repo:license/text(),
+            "authors": array{ $repo//repo:author/text() },
+            "type": $repo//repo:type/text(),
+            "target": $repo//repo:target/text()
+            (: ,"repo": $repo :)
+        }
+};
+
+declare
+function local:get-deployment-date ($expath, $repo) {
+    let $doc :=
+        if ($repo?target)
+        then doc('/db/apps/' || $repo?target || '/repo.xml')
+        else doc('/db/system/repo/' || $expath?abbrev || '-' || $expath?version || '/repo.xml')
+
+    return $doc//repo:deployed/text()
+};
+
+declare
+function local:meta($package-uri as xs:string) as map(*) {
+    let $expath := local:expath($package-uri)
+    let $repo := local:repo($package-uri)
+
+    let $date := local:get-deployment-date($expath, $repo)
+
+    return map:merge((
+        map { "uri": $package-uri, 'date': $date },
+        $expath,
+        $repo
+    ))
+};
+
+serialize(
+    map {
+        "packages": array {
+            for-each(repo:list(), local:meta#1)
+        }
+    },
+    map { "method": "json" }
+)

--- a/modules/list-packages.xq
+++ b/modules/list-packages.xq
@@ -21,11 +21,11 @@ function local:get-package-meta(
 declare
 function local:dependency ($dep as element(expath:dependency)?) as map(*) {
     map {
-        "uri": ($dep/(@package|@processor))[1]/string(),
-        "min": $dep/@semver-min/string(),
-        "max": $dep/@semver-max/string(),
-        "template": $dep/@semver/string(),
-        "exact": array { tokenize($dep/@versions, ' ') }
+        "name": ($dep/(@package|@processor))[1]/string(),
+        "semverMin": $dep/@semver-min/string(),
+        "semverMax": $dep/@semver-max/string(),
+        "semver": $dep/@semver/string(),
+        "versions": array { tokenize($dep/@versions, ' ') }
     }
 };
 

--- a/modules/list-packages.xq
+++ b/modules/list-packages.xq
@@ -64,7 +64,7 @@ function local:expath($package-uri as xs:string) as map(*) {
 
     return
         map {
-            "uri": $expath//@name,
+            "name": $expath//@name,
             "abbrev": $expath//@abbrev/string(),
             "version": $expath//expath:package/@version/string(),
             "title": $expath//expath:title/text(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "bottleneck": "^2.19.5",
         "dotenv": "^16.0.3",
         "fast-glob": "^3.2.12",
+        "semver": "^7.3.8",
         "yargs": "^17.6.2"
       },
       "bin": {
@@ -4184,9 +4185,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.0"
@@ -4449,7 +4450,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -8274,7 +8274,6 @@
       "version": "7.3.8",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
       "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -9377,8 +9376,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
       "version": "1.10.2",
@@ -12532,9 +12530,9 @@
       "dev": true
     },
     "json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
@@ -12758,7 +12756,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -15436,7 +15433,6 @@
       "version": "7.3.8",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
       "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -16261,8 +16257,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
       "version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "node": "^14.18 || ^16.13 || >=18"
   },
   "scripts": {
-    "test": "standard && tape spec/tests/*.js",
+    "test": "standard && tape spec/tests/*.js spec/tests/**/*.js",
     "lint": "standard --fix"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "bottleneck": "^2.19.5",
     "dotenv": "^16.0.3",
     "fast-glob": "^3.2.12",
+    "semver": "^7.3.8",
     "yargs": "^17.6.2"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,8 @@ xst <command> --help
 - `get` download a collection or resource to the filesystem
 - `rm` remove collections and resources
 - `package` package related commands
-  - `install` upload and install a local XAR package 
+  - `install` upload and install a local XAR package
+  - `list` list installed packages
 - `execute` the swiss army knife command that lets you query data or run a main module
 
 ### Examples
@@ -131,6 +132,12 @@ xst package install path/to/my-package.xar
 ```
 
 NOTE: User that connects must be a database administrator.
+
+#### List all installed application packages with their dependencies
+
+```bash
+xst package list --applications --dependencies
+```
 
 ## Configuration
 

--- a/spec/tests/list.js
+++ b/spec/tests/list.js
@@ -275,6 +275,8 @@ test('with fixtures uploaded', async (t) => {
 /db/list-test/tests/package/list.js
 /db/list-test/tests/rm.js
 /db/list-test/tests/upload.js
+/db/list-test/tests/utility
+/db/list-test/tests/utility/version.js
 `
     st.equal(expectedlines, stdout, stdout)
     st.end()
@@ -297,6 +299,8 @@ test('with fixtures uploaded', async (t) => {
 /db/list-test/tests/package
 /db/list-test/tests/package/list.js
 /db/list-test/tests/package/install.js
+/db/list-test/tests/utility
+/db/list-test/tests/utility/version.js
 /db/list-test/tests/info.js
 /db/list-test/tests/cli.js
 /db/list-test/tests/upload.js

--- a/spec/tests/list.js
+++ b/spec/tests/list.js
@@ -269,8 +269,10 @@ test('with fixtures uploaded', async (t) => {
 /db/list-test/tests/exec.js
 /db/list-test/tests/get.js
 /db/list-test/tests/info.js
-/db/list-test/tests/install.js
 /db/list-test/tests/list.js
+/db/list-test/tests/package
+/db/list-test/tests/package/install.js
+/db/list-test/tests/package/list.js
 /db/list-test/tests/rm.js
 /db/list-test/tests/upload.js
 `
@@ -292,6 +294,9 @@ test('with fixtures uploaded', async (t) => {
 /db/list-test/fixtures/broken-test-app.xar
 /db/list-test/fixtures/test.xml
 /db/list-test/tests
+/db/list-test/tests/package
+/db/list-test/tests/package/list.js
+/db/list-test/tests/package/install.js
 /db/list-test/tests/info.js
 /db/list-test/tests/cli.js
 /db/list-test/tests/upload.js
@@ -299,7 +304,6 @@ test('with fixtures uploaded', async (t) => {
 /db/list-test/tests/exec.js
 /db/list-test/tests/rm.js
 /db/list-test/tests/get.js
-/db/list-test/tests/install.js
 /db/list-test/tests/list.js
 /db/list-test/test.xq
 /db/list-test/b

--- a/spec/tests/list.js
+++ b/spec/tests/list.js
@@ -9,7 +9,7 @@ async function prepare (t) {
   try {
     const phase1 = await run('xst', ['up', '-D', '-e', 'tests', testSourceFolder, testCollection], asAdmin)
     if (phase1.stderr) { throw Error(phase1.stderr) }
-    const ensureTestsOlder = await run('xst', ['up', testSourceFolder + '/tests', testCollection + '/tests'], asAdmin)
+    const ensureTestsOlder = await run('xst', ['up', '-e', 'package,utility', testSourceFolder + '/tests', testCollection + '/tests'], asAdmin)
     if (ensureTestsOlder.stderr) { throw Error(ensureTestsOlder.stderr) }
     await storeResource(testCollection, 'b', '"test"')
     await storeResource(testCollection, 'a.txt', '"test"')
@@ -32,7 +32,7 @@ async function storeResource (collection, fileName, content) {
 }
 
 async function cleanup (t) {
-  const { stderr, stdout } = await run('xst', ['run', `xmldb:remove("${testCollection}")`], asAdmin)
+  const { stderr, stdout } = await run('xst', ['rm', '-rf', testCollection], asAdmin)
   if (stderr) {
     t.fail(stderr)
   }
@@ -270,13 +270,8 @@ test('with fixtures uploaded', async (t) => {
 /db/list-test/tests/get.js
 /db/list-test/tests/info.js
 /db/list-test/tests/list.js
-/db/list-test/tests/package
-/db/list-test/tests/package/install.js
-/db/list-test/tests/package/list.js
 /db/list-test/tests/rm.js
 /db/list-test/tests/upload.js
-/db/list-test/tests/utility
-/db/list-test/tests/utility/version.js
 `
     st.equal(expectedlines, stdout, stdout)
     st.end()
@@ -296,11 +291,6 @@ test('with fixtures uploaded', async (t) => {
 /db/list-test/fixtures/broken-test-app.xar
 /db/list-test/fixtures/test.xml
 /db/list-test/tests
-/db/list-test/tests/package
-/db/list-test/tests/package/list.js
-/db/list-test/tests/package/install.js
-/db/list-test/tests/utility
-/db/list-test/tests/utility/version.js
 /db/list-test/tests/info.js
 /db/list-test/tests/cli.js
 /db/list-test/tests/upload.js

--- a/spec/tests/package/install.js
+++ b/spec/tests/package/install.js
@@ -1,5 +1,5 @@
 import { test } from 'tape'
-import { run, asAdmin } from '../test.js'
+import { run, asAdmin } from '../../test.js'
 
 const packageCollection = '/db/pkgtmp'
 const pkgUri = 'http://exist-db.org/apps/test-app'

--- a/spec/tests/package/list.js
+++ b/spec/tests/package/list.js
@@ -1,0 +1,97 @@
+import { test } from 'tape'
+import { run, asAdmin } from '../../test.js'
+
+const pkgUri = 'http://exist-db.org/apps/test-app'
+
+async function removeTestApp (t) {
+  const { stderr } = await run('xst', ['run', `repo:undeploy("${pkgUri}"),repo:remove("${pkgUri}")`], asAdmin)
+  if (stderr) {
+    console.error(stderr)
+    t.fail(stderr)
+  }
+}
+
+test('shows help', async function (t) {
+  const { stderr, stdout } = await run('xst', ['package', 'list', '--help'])
+
+  if (stderr) { return t.fail(stderr) }
+  t.ok(stdout, 'got output')
+  const firstLine = stdout.split('\n')[0]
+  t.equal(firstLine, 'xst package list [options]', firstLine)
+})
+
+test('with new package', async function (t) {
+  let firstInstallationDate
+  t.test('install extra package', async function (st) {
+    const { stderr, stdout } = await run('xst', ['package', 'install', 'spec/fixtures/test-app.xar'], asAdmin)
+    if (stderr) {
+      st.fail(stderr)
+      st.end()
+      return
+    }
+
+    const lines = stdout.split('\n')
+    st.equal(lines[0], 'Install test-app.xar on https://localhost:8443')
+    st.equal(lines[1], '✔︎ uploaded')
+    st.equal(lines[2], '✔︎ installed')
+    st.end()
+  })
+
+  t.test('list', async function (st) {
+    const { stderr, stdout } = await run('xst', ['package', 'list', '--date', 'iso'], asAdmin)
+    if (stderr) {
+      st.fail(stderr)
+      st.end()
+      return
+    }
+
+    const lines = stdout.split('\n')
+    const found = lines.filter(l => l.contains('test-app'))
+    st.ok(found.length, found[0])
+    firstInstallationDate = found.match(/\w+ (.*)$/)
+    st.ok(firstInstallationDate, firstInstallationDate)
+    st.end()
+  })
+
+  t.test('update extra package', async function (st) {
+    const { stderr, stdout } = await run('xst', ['package', 'install', 'spec/fixtures/test-app.xar'], asAdmin)
+    if (stderr) {
+      st.fail(stderr)
+      st.end()
+      return
+    }
+
+    const lines = stdout.split('\n')
+    st.equal(lines[0], 'Install test-app.xar on https://localhost:8443')
+    st.equal(lines[1], '✔︎ uploaded')
+    st.equal(lines[2], '✔︎ updated')
+    st.end()
+  })
+
+  t.test('list has updated', async function (st) {
+    const { stderr, stdout } = await run('xst', ['package', 'list', '--date', 'iso'], asAdmin)
+    if (stderr) {
+      st.fail(stderr)
+      st.end()
+      return
+    }
+
+    const lines = stdout.split('\n')
+    const found = lines.filter(l => l.contains('test-app'))
+    st.ok(found.length, found[0])
+    const newInstallationDate = found.match(/\w+ (.*)$/)
+    st.notEqual(firstInstallationDate, newInstallationDate, 'installation date changed')
+    st.end()
+  })
+
+  t.teardown(removeTestApp)
+})
+
+test('error', async function (t) {
+  const { stderr, stdout } = await run('xst', ['pkg', 'ls', '-a', '-l'], asAdmin)
+  if (stdout) {
+    t.fail(stdout)
+    return
+  }
+  t.ok(stderr, stderr)
+})

--- a/spec/tests/package/list.js
+++ b/spec/tests/package/list.js
@@ -20,6 +20,14 @@ test('shows help', async function (t) {
   t.equal(firstLine, 'xst package list [options]', firstLine)
 })
 
+test('shows full name', async function (t) {
+  const { stderr, stdout } = await run('xst', ['package', 'list', '--full-name'])
+
+  if (stderr) { return t.fail(stderr) }
+  const lines = stdout.split('\n')
+  t.equal(lines[0], 'http://exist-db.org/apps/dashboard')
+})
+
 test('shows version', async function (t) {
   const { stderr, stdout } = await run('xst', ['package', 'list', '--versions'])
 
@@ -112,10 +120,11 @@ test('with new package', async function (t) {
     const { stderr, stdout } = await run('xst', ['package', 'list', '--extended', '--timesort'])
 
     if (stderr) { return t.fail(stderr) }
+    console.log(stdout)
     const lines = stdout.split('\n')
     st.ok(lines[0].startsWith('test-app'), lines[0])
     st.equal(lines[1], 'Title: Test App')
-    st.equal(lines[2], 'URI: http://exist-db.org/apps/test-app')
+    st.equal(lines[2], 'Name: http://exist-db.org/apps/test-app')
     st.equal(lines[3], 'Author: Somebody Important')
     st.equal(lines[4], 'Description: A test application')
     st.equal(lines[5], 'Website: http://exist-db.org/')

--- a/spec/tests/package/list.js
+++ b/spec/tests/package/list.js
@@ -20,25 +20,6 @@ test('shows help', async function (t) {
   t.equal(firstLine, 'xst package list [options]', firstLine)
 })
 
-test('shows extended output', async function (t) {
-  const { stderr, stdout } = await run('xst', ['package', 'list', '--extended'])
-
-  if (stderr) { return t.fail(stderr) }
-  const lines = stdout.split('\n')
-  t.equal(lines[0], 'dashboard          ')
-  t.equal(lines[1], 'Title: Dashboard')
-  t.equal(lines[2], 'URI: http://exist-db.org/apps/dashboard')
-  t.equal(lines[3], 'Author: Joern Turner')
-  t.equal(lines[4], 'Description: Dashboard')
-  t.ok(lines[5].startsWith('Version: '), lines[5])
-  t.ok(lines[6].startsWith('Installed: '), lines[6])
-  t.ok(lines[7].startsWith('Processor: existdb'), lines[7])
-  t.equal(lines[8], 'Target: dashboard')
-  t.equal(lines[9], 'Type: application')
-  t.equal(lines[10], 'License: GNU-LGPL')
-  t.equal(lines[11], '')
-})
-
 test('shows version', async function (t) {
   const { stderr, stdout } = await run('xst', ['package', 'list', '--versions'])
 
@@ -125,6 +106,26 @@ test('with new package', async function (t) {
     if (stderr) { return t.fail(stderr) }
     const lines = stdout.split('\n')
     st.equal(lines.shift(), 'test-app', 'test-app is first')
+  })
+
+  t.test('shows extended output of test-app', async function (st) {
+    const { stderr, stdout } = await run('xst', ['package', 'list', '--extended', '--timesort'])
+
+    if (stderr) { return t.fail(stderr) }
+    const lines = stdout.split('\n')
+    st.ok(lines[0].startsWith('test-app'), lines[0])
+    st.equal(lines[1], 'Title: Test App')
+    st.equal(lines[2], 'URI: http://exist-db.org/apps/test-app')
+    st.equal(lines[3], 'Author: Somebody Important')
+    st.equal(lines[4], 'Description: A test application')
+    st.equal(lines[5], 'Website: http://exist-db.org/')
+    st.ok(lines[6].startsWith('Version: '), lines[6])
+    st.ok(lines[7].startsWith('Installed: '), lines[7])
+    st.equal(lines[8], 'Processor: any')
+    st.equal(lines[9], 'Target: test-app')
+    st.equal(lines[10], 'Type: application')
+    st.equal(lines[11], 'License: WTF')
+    st.equal(lines[12], '')
   })
 
   t.test('sorts by installation date (reversed)', async function (st) {

--- a/spec/tests/package/list.js
+++ b/spec/tests/package/list.js
@@ -20,6 +20,72 @@ test('shows help', async function (t) {
   t.equal(firstLine, 'xst package list [options]', firstLine)
 })
 
+test('shows extended output', async function (t) {
+  const { stderr, stdout } = await run('xst', ['package', 'list', '--extended'])
+
+  if (stderr) { return t.fail(stderr) }
+  const lines = stdout.split('\n')
+  t.equal(lines[0], 'dashboard          ')
+  t.equal(lines[1], 'Title: Dashboard')
+  t.equal(lines[2], 'URI: http://exist-db.org/apps/dashboard')
+  t.equal(lines[3], 'Author: Joern Turner')
+  t.equal(lines[4], 'Description: Dashboard')
+  t.ok(lines[5].startsWith('Version: '), lines[5])
+  t.ok(lines[6].startsWith('Installed: '), lines[6])
+  t.ok(lines[7].startsWith('Processor: existdb'), lines[7])
+  t.equal(lines[8], 'Target: dashboard')
+  t.equal(lines[9], 'Type: application')
+  t.equal(lines[10], 'License: GNU-LGPL')
+  t.equal(lines[11], '')
+})
+
+test('shows version', async function (t) {
+  const { stderr, stdout } = await run('xst', ['package', 'list', '--versions'])
+
+  if (stderr) { return t.fail(stderr) }
+  const lines = stdout.split('\n')
+  t.ok(lines[0].match(/^[a-zA-Z0-9-]+ +\d+\.\d+(\.\d+(-[^ ]+)?)? *$/)[0], lines[0])
+})
+
+test('shows dependencies', async function (t) {
+  const { stderr, stdout } = await run('xst', ['package', 'list', '--dependencies'])
+
+  if (stderr) { return t.fail(stderr) }
+  t.ok(stdout, 'got output')
+})
+
+test('filters by type (libraries)', async function (t) {
+  const { stderr, stdout } = await run('xst', ['package', 'list', '--lib'])
+
+  if (stderr) { return t.fail(stderr) }
+  const lines = stdout.split('\n')
+  t.equal(lines[0], 'functx')
+})
+
+test('filters by type (application)', async function (t) {
+  const { stderr, stdout } = await run('xst', ['package', 'list', '--app'])
+
+  if (stderr) { return t.fail(stderr) }
+  const lines = stdout.split('\n')
+  t.equal(lines[0], 'dashboard')
+})
+
+test('sorts by type', async function (t) {
+  const { stderr, stdout } = await run('xst', ['package', 'list', '--typesort'])
+
+  if (stderr) { return t.fail(stderr) }
+  const lines = stdout.split('\n')
+  t.equal(lines[0], 'dashboard')
+})
+
+test.skip('sorts by type and installation date', async function (t) {
+  const { stderr, stdout } = await run('xst', ['package', 'list', '--typesort', '--timesort'])
+
+  if (stderr) { return t.fail(stderr) }
+  const lines = stdout.split('\n')
+  t.equal(lines[0], 'Install test-app.xar on https://localhost:8443')
+})
+
 test('with new package', async function (t) {
   let firstInstallationDate
   t.test('install extra package', async function (st) {
@@ -46,11 +112,27 @@ test('with new package', async function (t) {
     }
 
     const lines = stdout.split('\n')
-    const found = lines.filter(l => l.contains('test-app'))
+    const found = lines.filter(line => line.startsWith('test-app'))
     st.ok(found.length, found[0])
-    firstInstallationDate = found.match(/\w+ (.*)$/)
-    st.ok(firstInstallationDate, firstInstallationDate)
+    firstInstallationDate = new Date(found[0].match(/\d+-.+$/)[0])
+    st.ok(firstInstallationDate, 'first installation date')
     st.end()
+  })
+
+  t.test('sorts by installation date', async function (st) {
+    const { stderr, stdout } = await run('xst', ['package', 'list', '--timesort'])
+
+    if (stderr) { return t.fail(stderr) }
+    const lines = stdout.split('\n')
+    st.equal(lines.shift(), 'test-app', 'test-app is first')
+  })
+
+  t.test('sorts by installation date (reversed)', async function (st) {
+    const { stderr, stdout } = await run('xst', ['package', 'list', '--timesort', '--reverse'])
+
+    if (stderr) { return t.fail(stderr) }
+    const lines = stdout.split('\n')
+    st.equal(lines[lines.length - 2], 'test-app', 'test-app is last')
   })
 
   t.test('update extra package', async function (st) {
@@ -77,10 +159,10 @@ test('with new package', async function (t) {
     }
 
     const lines = stdout.split('\n')
-    const found = lines.filter(l => l.contains('test-app'))
+    const found = lines.filter(line => line.startsWith('test-app'))
     st.ok(found.length, found[0])
-    const newInstallationDate = found.match(/\w+ (.*)$/)
-    st.notEqual(firstInstallationDate, newInstallationDate, 'installation date changed')
+    const newInstallationDate = new Date(found[0].match(/\d+-.+$/)[0])
+    st.ok(newInstallationDate.getTime() > firstInstallationDate.getTime(), 'installation date changed')
     st.end()
   })
 

--- a/spec/tests/utility/version.js
+++ b/spec/tests/utility/version.js
@@ -1,21 +1,36 @@
 import { test } from 'tape'
-import { satisfiesDependency, formatVersion } from '../../../utility/version.js'
+import { satisfiesDependency, formatVersion, formatVersionFill } from '../../../utility/version.js'
 
 test('with semver-max="5"', function (t) {
   const max5 = {
+    min: null,
     max: '5',
     template: null,
-    min: null,
     exact: []
   }
   t.test('renders', function (st) {
     const formatted = formatVersion(max5)
-    st.equals(formatted, '~5', formatted)
+    st.equals(formatted, '<=5', formatted)
+    st.end()
+  })
+  t.test('renders filled', function (st) {
+    const formatted = formatVersionFill(max5)
+    st.equals(formatted, '<=5.x.x', formatted)
     st.end()
   })
 
-  t.test('5.999.999', function (st) {
-    const satisfied = satisfiesDependency('5.999.999', max5)
+  t.test('lizard', function (st) {
+    const satisfied = satisfiesDependency('lizard', max5)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
+  t.test('(null)', function (st) {
+    const satisfied = satisfiesDependency(null, max5)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
+  t.test('1.0.0', function (st) {
+    const satisfied = satisfiesDependency('1.0.0', max5)
     st.ok(satisfied, 'should satisfy')
     st.end()
   })
@@ -24,7 +39,11 @@ test('with semver-max="5"', function (t) {
     st.ok(satisfied, 'should satisfy')
     st.end()
   })
-
+  t.test('5.999.999', function (st) {
+    const satisfied = satisfiesDependency('5.999.999', max5)
+    st.ok(satisfied, 'should satisfy')
+    st.end()
+  })
   t.test('6.0.0', function (st) {
     const satisfied = satisfiesDependency('6.0.0', max5)
     st.notOk(satisfied, 'should not satisfy')
@@ -34,19 +53,25 @@ test('with semver-max="5"', function (t) {
 
 test('with semver-max="5.2"', function (t) {
   const max52 = {
+    min: null,
     max: '5.2',
     template: null,
-    min: null,
     exact: []
   }
   t.test('renders', function (st) {
     const formatted = formatVersion(max52)
-    st.equals(formatted, '~5.2', formatted)
+    st.equals(formatted, '<=5.2', formatted)
     st.end()
   })
-  t.test('5.999.999', function (st) {
-    const satisfied = satisfiesDependency('5.999.999', max52)
-    st.notOk(satisfied, 'should not satisfy')
+  t.test('renders filled', function (st) {
+    const formatted = formatVersionFill(max52)
+    st.equals(formatted, '<=5.2.x', formatted)
+    st.end()
+  })
+
+  t.test('1.0.0', function (st) {
+    const satisfied = satisfiesDependency('1.0.0', max52)
+    st.ok(satisfied, 'should satisfy')
     st.end()
   })
   t.test('5.0.0', function (st) {
@@ -54,7 +79,21 @@ test('with semver-max="5.2"', function (t) {
     st.ok(satisfied, 'should satisfy')
     st.end()
   })
-
+  t.test('5.2.0', function (st) {
+    const satisfied = satisfiesDependency('5.2.0', max52)
+    st.ok(satisfied, 'should satisfy')
+    st.end()
+  })
+  t.test('5.2.1', function (st) {
+    const satisfied = satisfiesDependency('5.2.1', max52)
+    st.ok(satisfied, 'should satisfy')
+    st.end()
+  })
+  t.test('5.999.999', function (st) {
+    const satisfied = satisfiesDependency('5.999.999', max52)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
   t.test('6.0.0', function (st) {
     const satisfied = satisfiesDependency('6.0.0', max52)
     st.notOk(satisfied, 'should not satisfy')
@@ -64,9 +103,9 @@ test('with semver-max="5.2"', function (t) {
 
 test('with semver-max="5.2.1"', function (t) {
   const max521 = {
+    min: null,
     max: '5.2.1',
     template: null,
-    min: null,
     exact: []
   }
   t.test('renders', function (st) {
@@ -74,11 +113,12 @@ test('with semver-max="5.2.1"', function (t) {
     st.equals(formatted, '<=5.2.1', formatted)
     st.end()
   })
-  t.test('5.999.999', function (st) {
-    const satisfied = satisfiesDependency('5.999.999', max521)
-    st.notOk(satisfied, 'should not satisfy')
+  t.test('renders filled', function (st) {
+    const formatted = formatVersionFill(max521)
+    st.equals(formatted, '<=5.2.1', formatted)
     st.end()
   })
+
   t.test('5.2.0', function (st) {
     const satisfied = satisfiesDependency('5.2.0', max521)
     st.ok(satisfied, 'should satisfy')
@@ -89,7 +129,11 @@ test('with semver-max="5.2.1"', function (t) {
     st.ok(satisfied, 'should satisfy')
     st.end()
   })
-
+  t.test('5.999.999', function (st) {
+    const satisfied = satisfiesDependency('5.999.999', max521)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
   t.test('6.0.0', function (st) {
     const satisfied = satisfiesDependency('6.0.0', max521)
     st.notOk(satisfied, 'should not satisfy')
@@ -109,6 +153,12 @@ test('with semver-min="5"', function (t) {
     st.equals(formatted, '>=5', formatted)
     st.end()
   })
+  t.test('renders filled', function (st) {
+    const formatted = formatVersionFill(min5)
+    st.equals(formatted, '>=5.x.x', formatted)
+    st.end()
+  })
+
   t.test('4.0.0', function (st) {
     const satisfied = satisfiesDependency('4.0.0', min5)
     st.notOk(satisfied, 'should not satisfy')
@@ -134,8 +184,8 @@ test('with semver-min="5"', function (t) {
 test('with semver-min="5.2"', function (t) {
   const min52 = {
     min: '5.2',
-    template: null,
     max: null,
+    template: null,
     exact: []
   }
   t.test('renders', function (st) {
@@ -143,6 +193,12 @@ test('with semver-min="5.2"', function (t) {
     st.equals(formatted, '>=5.2', formatted)
     st.end()
   })
+  t.test('renders filled', function (st) {
+    const formatted = formatVersionFill(min52)
+    st.equals(formatted, '>=5.2.x', formatted)
+    st.end()
+  })
+
   t.test('4.0.0', function (st) {
     const satisfied = satisfiesDependency('4.0.0', min52)
     st.notOk(satisfied, 'should not satisfy')
@@ -178,13 +234,29 @@ test('with semver-min="5.2"', function (t) {
 test('with semver-min="5.2.1"', function (t) {
   const min521 = {
     min: '5.2.1',
-    template: null,
     max: null,
+    template: null,
     exact: []
   }
   t.test('renders', function (st) {
     const formatted = formatVersion(min521)
     st.equals(formatted, '>=5.2.1', formatted)
+    st.end()
+  })
+  t.test('renders filled', function (st) {
+    const formatted = formatVersionFill(min521)
+    st.equals(formatted, '>=5.2.1', formatted)
+    st.end()
+  })
+
+  t.test('lizard', function (st) {
+    const satisfied = satisfiesDependency('lizard', min521)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
+  t.test('(null)', function (st) {
+    const satisfied = satisfiesDependency(null, min521)
+    st.notOk(satisfied, 'should not satisfy')
     st.end()
   })
   t.test('4.0.0', function (st) {
@@ -246,6 +318,22 @@ test('with semver-min="5.2" and semver-max="5.4.1"', function (t) {
     st.equals(formatted, '5.2 - 5.4.1', formatted)
     st.end()
   })
+  t.test('renders filled', function (st) {
+    const formatted = formatVersionFill(range5)
+    st.equals(formatted, '5.2.x - 5.4.1', formatted)
+    st.end()
+  })
+
+  t.test('lizard', function (st) {
+    const satisfied = satisfiesDependency('lizard', range5)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
+  t.test('(null)', function (st) {
+    const satisfied = satisfiesDependency(null, range5)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
   t.test('4.0.0', function (st) {
     const satisfied = satisfiesDependency('4.0.0', range5)
     st.notOk(satisfied, 'should not satisfy')
@@ -305,14 +393,30 @@ test('with semver-min="5.2" and semver-max="5.4.1"', function (t) {
 
 test('with semver="5.2.1"', function (t) {
   const template521 = {
-    template: '5.2.1',
     max: null,
     min: null,
+    template: '5.2.1',
     exact: []
   }
   t.test('renders', function (st) {
     const formatted = formatVersion(template521)
-    st.equals(formatted, '^5.2.1', formatted)
+    st.equals(formatted, '5.2.1', formatted)
+    st.end()
+  })
+  t.test('renders filled', function (st) {
+    const formatted = formatVersionFill(template521)
+    st.equals(formatted, '5.2.1', formatted)
+    st.end()
+  })
+
+  t.test('lizard', function (st) {
+    const satisfied = satisfiesDependency('lizard', template521)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
+  t.test('(null)', function (st) {
+    const satisfied = satisfiesDependency(null, template521)
+    st.notOk(satisfied, 'should not satisfy')
     st.end()
   })
   t.test('5.0.0', function (st) {
@@ -349,28 +453,40 @@ test('with semver="5.2.1"', function (t) {
 
 test('with versions="asdf 5.2.1"', function (t) {
   const exact = {
-    template: null,
-    max: null,
     min: null,
-    exact: ['asdf', '5.2.1']
+    max: null,
+    template: null,
+    exact: ['freeform', '5.2.1']
   }
+  t.test('renders', function (st) {
+    const formatted = formatVersion(exact)
+    st.equals(formatted, 'freeform || 5.2.1', formatted)
+    st.end()
+  })
+  t.test('renders filled', function (st) {
+    const formatted = formatVersionFill(exact)
+    st.equals(formatted, 'freeform || 5.2.1', formatted)
+    st.end()
+  })
+
   t.test('5.2.1', function (st) {
     const satisfied = satisfiesDependency('5.2.1', exact)
     st.ok(satisfied, 'should satisfy')
     st.end()
   })
   t.test('asdf', function (st) {
-    const satisfied = satisfiesDependency('asdf', exact)
+    const satisfied = satisfiesDependency('freeform', exact)
     st.ok(satisfied, 'should satisfy')
     st.end()
   })
-  t.test('renders', function (st) {
-    const formatted = formatVersion(exact)
-    st.equals(formatted, 'asdf || 5.2.1', formatted)
+
+  t.test('lizard', function (st) {
+    const satisfied = satisfiesDependency('', exact)
+    st.notOk(satisfied, 'should not satisfy')
     st.end()
   })
-  t.test('5.999.999', function (st) {
-    const satisfied = satisfiesDependency('5.999.999', exact)
+  t.test('(null)', function (st) {
+    const satisfied = satisfiesDependency(null, exact)
     st.notOk(satisfied, 'should not satisfy')
     st.end()
   })
@@ -379,9 +495,13 @@ test('with versions="asdf 5.2.1"', function (t) {
     st.notOk(satisfied, 'should not satisfy')
     st.end()
   })
-
   t.test('5.2.2', function (st) {
     const satisfied = satisfiesDependency('5.2.2', exact)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
+  t.test('5.999.999', function (st) {
+    const satisfied = satisfiesDependency('5.999.999', exact)
     st.notOk(satisfied, 'should not satisfy')
     st.end()
   })

--- a/spec/tests/utility/version.js
+++ b/spec/tests/utility/version.js
@@ -3,10 +3,10 @@ import { satisfiesDependency, formatVersion, formatVersionFill } from '../../../
 
 test('with semver-max="5"', function (t) {
   const max5 = {
-    min: null,
-    max: '5',
-    template: null,
-    exact: []
+    semverMin: null,
+    semverMax: '5',
+    semver: null,
+    versions: []
   }
   t.test('renders', function (st) {
     const formatted = formatVersion(max5)
@@ -44,6 +44,11 @@ test('with semver-max="5"', function (t) {
     st.ok(satisfied, 'should satisfy')
     st.end()
   })
+  t.test('6.0.0-SNAPSHOT', function (st) {
+    const satisfied = satisfiesDependency('6.0.0-SNAPSHOT', max5)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
   t.test('6.0.0', function (st) {
     const satisfied = satisfiesDependency('6.0.0', max5)
     st.notOk(satisfied, 'should not satisfy')
@@ -53,10 +58,10 @@ test('with semver-max="5"', function (t) {
 
 test('with semver-max="5.2"', function (t) {
   const max52 = {
-    min: null,
-    max: '5.2',
-    template: null,
-    exact: []
+    semverMin: null,
+    semverMax: '5.2',
+    semver: null,
+    versions: []
   }
   t.test('renders', function (st) {
     const formatted = formatVersion(max52)
@@ -103,10 +108,10 @@ test('with semver-max="5.2"', function (t) {
 
 test('with semver-max="5.2.1"', function (t) {
   const max521 = {
-    min: null,
-    max: '5.2.1',
-    template: null,
-    exact: []
+    semverMin: null,
+    semverMax: '5.2.1',
+    semver: null,
+    versions: []
   }
   t.test('renders', function (st) {
     const formatted = formatVersion(max521)
@@ -143,10 +148,10 @@ test('with semver-max="5.2.1"', function (t) {
 
 test('with semver-min="5"', function (t) {
   const min5 = {
-    min: '5',
-    max: null,
-    template: null,
-    exact: []
+    semverMin: '5',
+    semverMax: null,
+    semver: null,
+    versions: []
   }
   t.test('renders', function (st) {
     const formatted = formatVersion(min5)
@@ -162,6 +167,11 @@ test('with semver-min="5"', function (t) {
   t.test('4.0.0', function (st) {
     const satisfied = satisfiesDependency('4.0.0', min5)
     st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
+  t.test('5.0.0-SNAPSHOT', function (st) {
+    const satisfied = satisfiesDependency('5.0.0-SNAPSHOT', min5)
+    st.ok(satisfied, 'should satisfy')
     st.end()
   })
   t.test('5.0.0', function (st) {
@@ -183,10 +193,10 @@ test('with semver-min="5"', function (t) {
 
 test('with semver-min="5.2"', function (t) {
   const min52 = {
-    min: '5.2',
-    max: null,
-    template: null,
-    exact: []
+    semverMin: '5.2',
+    semverMax: null,
+    semver: null,
+    versions: []
   }
   t.test('renders', function (st) {
     const formatted = formatVersion(min52)
@@ -214,6 +224,11 @@ test('with semver-min="5.2"', function (t) {
     st.notOk(satisfied, 'should not satisfy')
     st.end()
   })
+  t.test('5.2.0-SNAPSHOT', function (st) {
+    const satisfied = satisfiesDependency('5.2.0-SNAPSHOT', min52)
+    st.ok(satisfied, 'should satisfy')
+    st.end()
+  })
   t.test('5.2.0', function (st) {
     const satisfied = satisfiesDependency('5.2.0', min52)
     st.ok(satisfied, 'should satisfy')
@@ -233,10 +248,10 @@ test('with semver-min="5.2"', function (t) {
 
 test('with semver-min="5.2.1"', function (t) {
   const min521 = {
-    min: '5.2.1',
-    max: null,
-    template: null,
-    exact: []
+    semverMin: '5.2.1',
+    semverMax: null,
+    semver: null,
+    versions: []
   }
   t.test('renders', function (st) {
     const formatted = formatVersion(min521)
@@ -279,6 +294,11 @@ test('with semver-min="5.2.1"', function (t) {
     st.notOk(satisfied, 'should not satisfy')
     st.end()
   })
+  t.test('5.2.1-SNAPSHOT', function (st) {
+    const satisfied = satisfiesDependency('5.2.1-SNAPSHOT', min521)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
   t.test('5.2.1', function (st) {
     const satisfied = satisfiesDependency('5.2.1', min521)
     st.ok(satisfied, 'should satisfy')
@@ -306,12 +326,31 @@ test('with semver-min="5.2.1"', function (t) {
   })
 })
 
+test('with semver-min="5.2.1-SNAPSHOT"', function (t) {
+  const min521 = {
+    semverMin: '5.2.1-SNAPSHOT',
+    semverMax: null,
+    semver: null,
+    versions: []
+  }
+  t.test('5.2.1-SNAPSHOT', function (st) {
+    const satisfied = satisfiesDependency('5.2.1-SNAPSHOT', min521)
+    st.ok(satisfied, 'should satisfy')
+    st.end()
+  })
+  t.test('5.2.1', function (st) {
+    const satisfied = satisfiesDependency('5.2.1', min521)
+    st.ok(satisfied, 'should satisfy')
+    st.end()
+  })
+})
+
 test('with semver-min="5.2" and semver-max="5.4.1"', function (t) {
   const range5 = {
-    min: '5.2',
-    max: '5.4.1',
-    template: null,
-    exact: []
+    semverMin: '5.2',
+    semverMax: '5.4.1',
+    semver: null,
+    versions: []
   }
   t.test('renders', function (st) {
     const formatted = formatVersion(range5)
@@ -393,10 +432,10 @@ test('with semver-min="5.2" and semver-max="5.4.1"', function (t) {
 
 test('with semver="5.2.1"', function (t) {
   const template521 = {
-    max: null,
-    min: null,
-    template: '5.2.1',
-    exact: []
+    semverMax: null,
+    semverMin: null,
+    semver: '5.2.1',
+    versions: []
   }
   t.test('renders', function (st) {
     const formatted = formatVersion(template521)
@@ -453,10 +492,10 @@ test('with semver="5.2.1"', function (t) {
 
 test('with versions="asdf 5.2.1"', function (t) {
   const exact = {
-    min: null,
-    max: null,
-    template: null,
-    exact: ['freeform', '5.2.1']
+    semverMin: null,
+    semverMax: null,
+    semver: null,
+    versions: ['freeform', '5.2.1']
   }
   t.test('renders', function (st) {
     const formatted = formatVersion(exact)
@@ -469,6 +508,11 @@ test('with versions="asdf 5.2.1"', function (t) {
     st.end()
   })
 
+  t.test('5.2.1-SNAPSHOT', function (st) {
+    const satisfied = satisfiesDependency('5.2.1-SNAPSHOT', exact)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
   t.test('5.2.1', function (st) {
     const satisfied = satisfiesDependency('5.2.1', exact)
     st.ok(satisfied, 'should satisfy')

--- a/spec/tests/utility/version.js
+++ b/spec/tests/utility/version.js
@@ -1,0 +1,393 @@
+import { test } from 'tape'
+import { satisfiesDependency, formatVersion } from '../../../utility/version.js'
+
+test('with semver-max="5"', function (t) {
+  const max5 = {
+    max: '5',
+    template: null,
+    min: null,
+    exact: []
+  }
+  t.test('renders', function (st) {
+    const formatted = formatVersion(max5)
+    st.equals(formatted, '~5', formatted)
+    st.end()
+  })
+
+  t.test('5.999.999', function (st) {
+    const satisfied = satisfiesDependency('5.999.999', max5)
+    st.ok(satisfied, 'should satisfy')
+    st.end()
+  })
+  t.test('5.0.0', function (st) {
+    const satisfied = satisfiesDependency('5.0.0', max5)
+    st.ok(satisfied, 'should satisfy')
+    st.end()
+  })
+
+  t.test('6.0.0', function (st) {
+    const satisfied = satisfiesDependency('6.0.0', max5)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
+})
+
+test('with semver-max="5.2"', function (t) {
+  const max52 = {
+    max: '5.2',
+    template: null,
+    min: null,
+    exact: []
+  }
+  t.test('renders', function (st) {
+    const formatted = formatVersion(max52)
+    st.equals(formatted, '~5.2', formatted)
+    st.end()
+  })
+  t.test('5.999.999', function (st) {
+    const satisfied = satisfiesDependency('5.999.999', max52)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
+  t.test('5.0.0', function (st) {
+    const satisfied = satisfiesDependency('5.0.0', max52)
+    st.ok(satisfied, 'should satisfy')
+    st.end()
+  })
+
+  t.test('6.0.0', function (st) {
+    const satisfied = satisfiesDependency('6.0.0', max52)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
+})
+
+test('with semver-max="5.2.1"', function (t) {
+  const max521 = {
+    max: '5.2.1',
+    template: null,
+    min: null,
+    exact: []
+  }
+  t.test('renders', function (st) {
+    const formatted = formatVersion(max521)
+    st.equals(formatted, '<=5.2.1', formatted)
+    st.end()
+  })
+  t.test('5.999.999', function (st) {
+    const satisfied = satisfiesDependency('5.999.999', max521)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
+  t.test('5.2.0', function (st) {
+    const satisfied = satisfiesDependency('5.2.0', max521)
+    st.ok(satisfied, 'should satisfy')
+    st.end()
+  })
+  t.test('5.0.0', function (st) {
+    const satisfied = satisfiesDependency('5.0.0', max521)
+    st.ok(satisfied, 'should satisfy')
+    st.end()
+  })
+
+  t.test('6.0.0', function (st) {
+    const satisfied = satisfiesDependency('6.0.0', max521)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
+})
+
+test('with semver-min="5"', function (t) {
+  const min5 = {
+    min: '5',
+    max: null,
+    template: null,
+    exact: []
+  }
+  t.test('renders', function (st) {
+    const formatted = formatVersion(min5)
+    st.equals(formatted, '>=5', formatted)
+    st.end()
+  })
+  t.test('4.0.0', function (st) {
+    const satisfied = satisfiesDependency('4.0.0', min5)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
+  t.test('5.0.0', function (st) {
+    const satisfied = satisfiesDependency('5.0.0', min5)
+    st.ok(satisfied, 'should satisfy')
+    st.end()
+  })
+  t.test('5.999.999', function (st) {
+    const satisfied = satisfiesDependency('5.999.999', min5)
+    st.ok(satisfied, 'should satisfy')
+    st.end()
+  })
+  t.test('6.0.0', function (st) {
+    const satisfied = satisfiesDependency('6.0.0', min5)
+    st.ok(satisfied, 'should satisfy')
+    st.end()
+  })
+})
+
+test('with semver-min="5.2"', function (t) {
+  const min52 = {
+    min: '5.2',
+    template: null,
+    max: null,
+    exact: []
+  }
+  t.test('renders', function (st) {
+    const formatted = formatVersion(min52)
+    st.equals(formatted, '>=5.2', formatted)
+    st.end()
+  })
+  t.test('4.0.0', function (st) {
+    const satisfied = satisfiesDependency('4.0.0', min52)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
+  t.test('5.0.0', function (st) {
+    const satisfied = satisfiesDependency('5.0.0', min52)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
+  t.test('5.1.0', function (st) {
+    const satisfied = satisfiesDependency('5.0.0', min52)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
+  t.test('5.2.0', function (st) {
+    const satisfied = satisfiesDependency('5.2.0', min52)
+    st.ok(satisfied, 'should satisfy')
+    st.end()
+  })
+  t.test('5.999.999', function (st) {
+    const satisfied = satisfiesDependency('5.999.999', min52)
+    st.ok(satisfied, 'should satisfy')
+    st.end()
+  })
+  t.test('6.0.0', function (st) {
+    const satisfied = satisfiesDependency('6.0.0', min52)
+    st.ok(satisfied, 'should satisfy')
+    st.end()
+  })
+})
+
+test('with semver-min="5.2.1"', function (t) {
+  const min521 = {
+    min: '5.2.1',
+    template: null,
+    max: null,
+    exact: []
+  }
+  t.test('renders', function (st) {
+    const formatted = formatVersion(min521)
+    st.equals(formatted, '>=5.2.1', formatted)
+    st.end()
+  })
+  t.test('4.0.0', function (st) {
+    const satisfied = satisfiesDependency('4.0.0', min521)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
+  t.test('5.0.0', function (st) {
+    const satisfied = satisfiesDependency('5.0.0', min521)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
+  t.test('5.1.0', function (st) {
+    const satisfied = satisfiesDependency('5.0.0', min521)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
+  t.test('5.2.0', function (st) {
+    const satisfied = satisfiesDependency('5.2.0', min521)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
+  t.test('5.2.1', function (st) {
+    const satisfied = satisfiesDependency('5.2.1', min521)
+    st.ok(satisfied, 'should satisfy')
+    st.end()
+  })
+  t.test('5.2.2', function (st) {
+    const satisfied = satisfiesDependency('5.2.2', min521)
+    st.ok(satisfied, 'should satisfy')
+    st.end()
+  })
+  t.test('5.3.0', function (st) {
+    const satisfied = satisfiesDependency('5.3.0', min521)
+    st.ok(satisfied, 'should satisfy')
+    st.end()
+  })
+  t.test('5.999.999', function (st) {
+    const satisfied = satisfiesDependency('5.999.999', min521)
+    st.ok(satisfied, 'should satisfy')
+    st.end()
+  })
+  t.test('6.0.0', function (st) {
+    const satisfied = satisfiesDependency('6.0.0', min521)
+    st.ok(satisfied, 'should satisfy')
+    st.end()
+  })
+})
+
+test('with semver-min="5.2" and semver-max="5.4.1"', function (t) {
+  const range5 = {
+    min: '5.2',
+    max: '5.4.1',
+    template: null,
+    exact: []
+  }
+  t.test('renders', function (st) {
+    const formatted = formatVersion(range5)
+    st.equals(formatted, '5.2 - 5.4.1', formatted)
+    st.end()
+  })
+  t.test('4.0.0', function (st) {
+    const satisfied = satisfiesDependency('4.0.0', range5)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
+  t.test('5.0.0', function (st) {
+    const satisfied = satisfiesDependency('5.0.0', range5)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
+  t.test('5.1.0', function (st) {
+    const satisfied = satisfiesDependency('5.0.0', range5)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
+  t.test('5.2.0', function (st) {
+    const satisfied = satisfiesDependency('5.2.0', range5)
+    st.ok(satisfied, 'should satisfy')
+    st.end()
+  })
+  t.test('5.2.1', function (st) {
+    const satisfied = satisfiesDependency('5.2.1', range5)
+    st.ok(satisfied, 'should satisfy')
+    st.end()
+  })
+  t.test('5.2.2', function (st) {
+    const satisfied = satisfiesDependency('5.2.2', range5)
+    st.ok(satisfied, 'should satisfy')
+    st.end()
+  })
+  t.test('5.3.0', function (st) {
+    const satisfied = satisfiesDependency('5.3.0', range5)
+    st.ok(satisfied, 'should satisfy')
+    st.end()
+  })
+  t.test('5.4.1', function (st) {
+    const satisfied = satisfiesDependency('5.4.1', range5)
+    st.ok(satisfied, 'should satisfy')
+    st.end()
+  })
+  t.test('5.4.2', function (st) {
+    const satisfied = satisfiesDependency('5.4.2', range5)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
+  t.test('5.5.0', function (st) {
+    const satisfied = satisfiesDependency('5.5.0', range5)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
+  t.test('6.0.0', function (st) {
+    const satisfied = satisfiesDependency('6.0.0', range5)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
+})
+
+test('with semver="5.2.1"', function (t) {
+  const template521 = {
+    template: '5.2.1',
+    max: null,
+    min: null,
+    exact: []
+  }
+  t.test('renders', function (st) {
+    const formatted = formatVersion(template521)
+    st.equals(formatted, '^5.2.1', formatted)
+    st.end()
+  })
+  t.test('5.0.0', function (st) {
+    const satisfied = satisfiesDependency('5.0.0', template521)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
+  t.test('5.2.0', function (st) {
+    const satisfied = satisfiesDependency('5.2.0', template521)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
+  t.test('5.2.1', function (st) {
+    const satisfied = satisfiesDependency('5.2.1', template521)
+    st.ok(satisfied, 'should satisfy')
+    st.end()
+  })
+  t.test('5.2.2', function (st) {
+    const satisfied = satisfiesDependency('5.2.2', template521)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
+  t.test('5.999.999', function (st) {
+    const satisfied = satisfiesDependency('5.999.999', template521)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
+  t.test('6.0.0', function (st) {
+    const satisfied = satisfiesDependency('6.0.0', template521)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
+})
+
+test('with versions="asdf 5.2.1"', function (t) {
+  const exact = {
+    template: null,
+    max: null,
+    min: null,
+    exact: ['asdf', '5.2.1']
+  }
+  t.test('5.2.1', function (st) {
+    const satisfied = satisfiesDependency('5.2.1', exact)
+    st.ok(satisfied, 'should satisfy')
+    st.end()
+  })
+  t.test('asdf', function (st) {
+    const satisfied = satisfiesDependency('asdf', exact)
+    st.ok(satisfied, 'should satisfy')
+    st.end()
+  })
+  t.test('renders', function (st) {
+    const formatted = formatVersion(exact)
+    st.equals(formatted, 'asdf || 5.2.1', formatted)
+    st.end()
+  })
+  t.test('5.999.999', function (st) {
+    const satisfied = satisfiesDependency('5.999.999', exact)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
+  t.test('5.2.0', function (st) {
+    const satisfied = satisfiesDependency('5.2.0', exact)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
+
+  t.test('5.2.2', function (st) {
+    const satisfied = satisfiesDependency('5.2.2', exact)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
+  t.test('6.0.0', function (st) {
+    const satisfied = satisfiesDependency('6.0.0', exact)
+    st.notOk(satisfied, 'should not satisfy')
+    st.end()
+  })
+})

--- a/utility/colored-date.js
+++ b/utility/colored-date.js
@@ -1,0 +1,71 @@
+import { ct } from './console.js'
+
+const timeFormat = {
+  hour12: false,
+  hour: '2-digit',
+  minute: '2-digit'
+}
+const dateFormat = {
+  month: 'short'
+}
+
+const now = new Date()
+const currentYear = now.getFullYear()
+const nowMs = now.getTime()
+
+/**
+ * format date to short representation
+ * @param {Date} date
+ * @returns {String} formatted date
+ */
+function formatDateShort (date) {
+  const year = date.getFullYear()
+  const month = date.toLocaleDateString('iso', dateFormat)
+  const day = date.getDate().toString().padStart(3)
+  if (year < currentYear) {
+    return month + day + year.toString().padStart(6)
+  }
+  const time = date.toLocaleTimeString('iso', timeFormat).padStart(6)
+  return month + day + time
+}
+
+const quarterHour = 900000
+const hour = 3600000
+const day = 86400000
+const month = 2592000000
+const quarterYear = 7776000000
+const year = 31104000000
+const steps = [year, quarterYear, month, day, hour, quarterHour]
+const greens = [70, 34, 40, 114, 84, 156]
+
+/**
+ * receive a color from the greens palette to color a date
+ * relative to the current date
+ * @param {Date} date the date to get the color for
+ * @returns {Number} xterm256color
+ */
+function colorForDate (date) {
+  const msSince = nowMs - date.getTime()
+  const index = steps.reduce((acc, next, step) => (msSince < next ? step : acc), 0)
+  return greens[index]
+}
+
+/**
+ * get date formatting function
+ * @param {ListOptions} options list rendering options
+ * @returns {(item:ListResultItem) => String} date formatting function
+ */
+export function getDateFormatter (options, prop) {
+  let formatter = formatDateShort
+  if (options.date === 'iso') {
+    formatter = (date) => date.toISOString()
+  }
+  if (options.color) {
+    return (item) => {
+      const date = new Date(item[prop])
+      const formattedDate = formatter(date)
+      return ct(formattedDate, colorForDate(date))
+    }
+  }
+  return (item) => formatter(new Date(item[prop]))
+}

--- a/utility/padding.js
+++ b/utility/padding.js
@@ -1,13 +1,16 @@
 /**
  * @typedef {Map<String, Number>} BlockPaddings
  */
+/**
+ * @typedef {(paddings:BlockPaddings, next:Object) => BlockPaddings} PaddingReduceer
+ */
 
 /**
  * Get maximum needed paddings for properties
  * Only properties that are part of initial paddings keys
  * will be checked
  * @param {BlockPaddings} paddings
- * @param {ListResultItem} next
+ * @param {Object} next next item to check
  * @returns {BlockPaddings} actual paddings
  */
 export function padReducer (paddings, next) {
@@ -17,4 +20,30 @@ export function padReducer (paddings, next) {
     }
   }
   return paddings
+}
+
+/**
+ * Get maximum needed paddings for properties
+ * Only properties that are part of initial paddings keys
+ * will be checked
+ * Recursively descend into tree for given prop, if set
+ * @param {String} treeProperty property with array of descendants
+ * @return {PaddingReduceer} recursive reducer
+ */
+export function recursivePadReducer (treeProperty) {
+  const descendantAccessor = (item) => item[treeProperty]
+  /**
+   * @param {BlockPaddings} paddings
+   * @param {Object} next next item to check
+   * @returns {BlockPaddings} actual paddings
+   */
+  const reducer = function (paddings, next) {
+    const newPaddings = padReducer(paddings, next)
+    const descendants = descendantAccessor(next)
+    if (descendants && descendants.length) {
+      return descendants.reduce(reducer, newPaddings)
+    }
+    return newPaddings
+  }
+  return reducer
 }

--- a/utility/padding.js
+++ b/utility/padding.js
@@ -1,0 +1,20 @@
+/**
+ * @typedef {Map<String, Number>} BlockPaddings
+ */
+
+/**
+ * Get maximum needed paddings for properties
+ * Only properties that are part of initial paddings keys
+ * will be checked
+ * @param {BlockPaddings} paddings
+ * @param {ListResultItem} next
+ * @returns {BlockPaddings} actual paddings
+ */
+export function padReducer (paddings, next) {
+  for (const key of paddings.keys()) {
+    if (paddings.get(key) < next[key].length) {
+      paddings.set(key, next[key].length)
+    }
+  }
+  return paddings
+}

--- a/utility/sorter.js
+++ b/utility/sorter.js
@@ -1,0 +1,24 @@
+
+/**
+ * @typedef {(itemA:ListResultItem, itemB:ListResultItem) => Number} ItemSorter
+ */
+
+/**
+ * sort items by multiple data points
+ * order of sorters defines priority
+ * can be reversed
+ * @param {*} a item A to compare
+ * @param {*} b item B to compare
+ * @param {ItemSorter[]} sorters item sorting functions
+ * @param {Boolean} reverse reverse sorting order?
+ */
+export function multiSort (a, b, sorters, reverse) {
+  let v = 0
+  let i = 0
+  let sf = sorters[i]
+  while (v === 0 && sf) {
+    v = reverse ? sf(b, a) : sf(a, b)
+    sf = sorters[++i]
+  }
+  return v
+}

--- a/utility/version.js
+++ b/utility/version.js
@@ -1,4 +1,4 @@
-import { coerce, valid, satisfies, gte } from 'semver'
+import { valid, satisfies } from 'semver'
 
 /**
  * @typedef {Object} VersionedItem
@@ -24,7 +24,78 @@ function doesNotDeclareVersion (versionedItem) {
 }
 
 /**
- * helper function to check if version satisfies versioned item
+ * How many parts (major, minor, patch) are in the template?
+ * @param {string} template version string with 0-2 dots
+ * @returns {1|2|3} parts in version string (max 3)
+ */
+function inspect (template) {
+  const parts = template.split('.').length
+  return Math.min(3, parts)
+}
+
+/**
+ * helper function to render version ranges and templates
+ * @param {VersionedItem} versionedItem the versioned item
+ * @returns {String} the formatted version
+ */
+export function formatVersion (versionedItem) {
+  if (doesNotDeclareVersion(versionedItem)) { return '*' }
+  if (versionedItem.template) {
+    switch (inspect(versionedItem.template)) {
+      case 3: return versionedItem.template
+      default: return '~' + versionedItem.template
+    }
+  }
+  if (versionedItem.min && versionedItem.max) {
+    return versionedItem.min + ' - ' + versionedItem.max
+  }
+  if (versionedItem.min) {
+    return '>=' + versionedItem.min
+  }
+  if (versionedItem.max) {
+    return '<=' + versionedItem.max
+  }
+  return versionedItem.exact.join(' || ')
+}
+
+/**
+ * alternative display of SemVer templates
+ * "5" will display as "5.x.x" default is "~5"
+ * @param {String} semverTemplate SemVer template string
+ * @returns {String} filled SemVer template string
+ */
+function fill (semverTemplate) {
+  switch (inspect(semverTemplate)) {
+    case 3: return semverTemplate
+    case 2: return semverTemplate + '.x'
+    default: return semverTemplate + '.x.x'
+  }
+}
+
+/**
+ * helper function to render alternative version (filled)
+ * @param {VersionedItem} versionedItem the versioned item
+ * @returns {String} the formatted version
+ */
+export function formatVersionFill (versionedItem) {
+  if (doesNotDeclareVersion(versionedItem)) { return '*' }
+  if (versionedItem.template) {
+    return fill(versionedItem.template)
+  }
+  if (versionedItem.min && versionedItem.max) {
+    return fill(versionedItem.min) + ' - ' + fill(versionedItem.max)
+  }
+  if (versionedItem.min) {
+    return '>=' + fill(versionedItem.min)
+  }
+  if (versionedItem.max) {
+    return '<=' + fill(versionedItem.max)
+  }
+  return versionedItem.exact.join(' || ')
+}
+
+/**
+ * check if version satisfies versioned item declaration
  * @param {String} version the versioned item
  * @param {VersionedItem} versionedItem the versioned item
  * @returns {Boolean} given version satisfies dependency
@@ -41,61 +112,5 @@ export function satisfiesDependency (version, versionedItem) {
   if (!semVer || versionedItem.exact.length) {
     return versionedItem.exact.includes(version)
   }
-  if (versionedItem.max && versionedItem.min) {
-    return satisfies(semVer, versionedItem.min + ' - ' + versionedItem.max)
-  }
-  if (versionedItem.min) {
-    return gte(semVer, coerce(versionedItem.min))
-  }
-  if (versionedItem.max) {
-    switch (inspect(versionedItem.max)) {
-      case 3: return satisfies(semVer, '<=' + versionedItem.max)
-      case 2: return satisfies(semVer, '<=' + versionedItem.max)
-      default: return satisfies(semVer, '~' + versionedItem.max)
-    }
-  }
-  switch (inspect(versionedItem.template)) {
-    case 3: return satisfies(semVer, versionedItem.template)
-    default: return satisfies(semVer, '~' + versionedItem.max)
-  }
-}
-
-function inspect (template) {
-  return template.split('.').length
-}
-
-// function fill (template) {
-//   switch (inspect(template)) {
-//     case 3: return template
-//     case 2: return template + '.x'
-//     default: return template + '.x.x'
-//   }
-// }
-
-/**
- * helper function to render version ranges and templates
- * @param {VersionedItem} versionedItem the versioned item
- * @returns {String} the formatted version
- */
-export function formatVersion (versionedItem) {
-  if (doesNotDeclareVersion(versionedItem)) { return '*' }
-  if (versionedItem.template) {
-    switch (inspect(versionedItem.template)) {
-      case 3: return '^' + versionedItem.template
-      default: return '~' + versionedItem.template
-    }
-  }
-  if (versionedItem.min && versionedItem.max) {
-    return versionedItem.min + ' - ' + versionedItem.max
-  }
-  if (versionedItem.min) {
-    return '>=' + versionedItem.min
-  }
-  if (versionedItem.max) {
-    switch (inspect(versionedItem.max)) {
-      case 3: return '<=' + versionedItem.max
-      default: return '~' + versionedItem.max
-    }
-  }
-  return versionedItem.exact.join(' || ')
+  return satisfies(semVer, formatVersion(versionedItem))
 }

--- a/utility/version.js
+++ b/utility/version.js
@@ -2,7 +2,7 @@ import { valid, satisfies } from 'semver'
 
 /**
  * @typedef {Object} VersionedItem
- * @prop {String} name package URI
+ * @prop {String} name package name
  * @prop {String} semverMin SemVer max version
  * @prop {String} semverMax SemVer min version
  * @prop {String} semver SemVer version range

--- a/utility/version.js
+++ b/utility/version.js
@@ -1,0 +1,82 @@
+import { coerce, valid, satisfies, gte, lte } from 'semver'
+
+/**
+ * @typedef {Object} VersionedItem
+ * @prop {String} name package URI
+ * @prop {String} min SemVer version
+ * @prop {String} max SemVer version
+ * @prop {String} template SemVer version template
+ * @prop {String[]} exact list of versions
+ */
+
+/**
+ * true, if the versioned item does not specify any version
+ * @param {VersionedItem} versionedItem the versioned item
+ * @returns {Boolean} given version satisfies dependency
+ */
+function doesNotDeclareVersion (versionedItem) {
+  return (
+    versionedItem.exact.length === 0 &&
+        versionedItem.max === null &&
+        versionedItem.min === null &&
+        versionedItem.template === null
+  )
+}
+
+/**
+ * helper function to check if version satisfies versioned item
+ * @param {String} version the versioned item
+ * @param {VersionedItem} versionedItem the versioned item
+ * @returns {Boolean} given version satisfies dependency
+ */
+export function satisfiesDependency (version, versionedItem) {
+  if (!version) {
+    return false
+  }
+  if (doesNotDeclareVersion(versionedItem)) {
+    return true
+  }
+  const semVer = valid(version)
+  if (!semVer && !versionedItem.exact) { return false }
+  if (!semVer) {
+    return versionedItem.exact.includes(version)
+  }
+  if (versionedItem.max && versionedItem.min) {
+    return satisfies(semVer, versionedItem.min + ' - ' + versionedItem.max)
+  }
+  if (versionedItem.min) {
+    return gte(semVer, coerce(versionedItem.min))
+  }
+  if (versionedItem.max) {
+    return lte(semVer, coerce(versionedItem.max))
+  }
+  const coerced = coerce(versionedItem.template, true)
+  return satisfies(semVer, coerced)
+}
+
+/**
+ * helper function to render version ranges and templates
+ * @param {VersionedItem} versionedItem the versioned item
+ * @returns {String} the formatted version
+ */
+export function formatVersion (versionedItem) {
+  if (doesNotDeclareVersion(versionedItem)) { return '*' }
+  if (versionedItem.template) {
+    const parts = versionedItem.template.split('.')
+    switch (parts.length) {
+      case 3: return versionedItem.template
+      case 2: return versionedItem.template + '.x'
+      default: return versionedItem.template + '.x.x'
+    }
+  }
+  if (versionedItem.min && versionedItem.max) {
+    return versionedItem.min + ' - ' + versionedItem.max
+  }
+  if (versionedItem.min) {
+    return '>=' + versionedItem.min
+  }
+  if (versionedItem.max) {
+    return '<=' + versionedItem.max
+  }
+  return versionedItem.exact.join(' || ')
+}


### PR DESCRIPTION
closes #7

```bash
xst package list [options]

List installed packages

Options:
      --version               Show version number                                          [boolean]
      --config                configuration to use
      --help                  Show help                                                    [boolean]
  -G, --color                 Color the output                            [boolean] [default: false]
  -V, --versions              Display installed version                   [boolean] [default: false]
  -e, --extended              Display more information for each item      [boolean] [default: false]
  -t, --typesort              Sort by type                                [boolean] [default: false]
  -T, --timesort              Sort by installation date                   [boolean] [default: false]
  -r, --reverse               Reverse the order of the sort                                [boolean]
  -a, --app, --applications   Only list installed application packages                     [boolean]
  -l, --lib, --libraries      Only list installed library packages                         [boolean]
      --date                  Show installation date                       [choices: "short", "iso"]
  -D, --deps, --dependencies  Show package dependencies                   [boolean] [default: false]
      --full-name             Use full name for packages and dependencies [boolean] [default: false]
      --raw                   Return raw JSON data from query             [boolean] [default: false]
```

Implements all options in #7 and then some. Except the ability to filter the list using a globbing expression.
This should rather be done as a separate command `xst package info <package-abbrev>`.