### PR TITLE
ci(commitlint): body-max-line-length severity

### DIFF
--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,1 +1,4 @@
-module.exports = { extends: ['@commitlint/config-conventional'] }
+module.exports = {
+  rule: { 'body-max-line-length': [1, 'always', 120] },
+  extends: ['@commitlint/config-conventional']
+}


### PR DESCRIPTION
Warn, if body line length exceeds 120 characters.
This was a failure before, which is problematic when using links.