### PR TITLE
fix issues in list command

### DIFF
--- a/commands/list.js
+++ b/commands/list.js
@@ -4,6 +4,7 @@ import { readXquery } from '../utility/xq.js'
 import { getDateFormatter } from '../utility/colored-date.js'
 import { multiSort } from '../utility/sorter.js'
 import { recursivePadReducer } from '../utility/padding.js'
+import { getSizeFormatter } from '../utility/size.js'
 
 /**
  * @typedef { import("node-exist").NodeExist } NodeExist
@@ -28,7 +29,7 @@ import { recursivePadReducer } from '../utility/padding.js'
  * @prop {Boolean} color color output or not
  * @prop {Boolean} long show more info per entry in list
  * @prop {boolean} collectionsOnly only show collections
- * @prop {"human"|"bytes"} size size in bytes
+ * @prop {"human"|"bytes"} size size format
  * @prop {"short"|"iso"} date format for dates
  * @prop {Boolean} recursive traverse the tree
  * @prop {Boolean} tree show output as a tree
@@ -236,50 +237,6 @@ function getPathRenderer (options) {
     return renderPath
   }
   return noOp
-}
-
-// size
-
-const FORMAT_SIZE_BASE = 1024
-const FORMAT_SIZE_PAD = 7
-
-/**
- * convert raw bytes to humand readable size string
- * @param {Number} size bytes
- * @returns {String} human readable size
- */
-function formatSizeHumanReadable (size) {
-  if (size === 0) {
-    return '0 B '.padStart(FORMAT_SIZE_PAD)
-  }
-  const power = Math.floor(Math.log(size) / Math.log(FORMAT_SIZE_BASE))
-  const _s = size / Math.pow(FORMAT_SIZE_BASE, power)
-  const _p = Math.floor(Math.log(_s) / Math.log(10))
-  const digits = _p < 2 ? 1 : 0
-  const humanReadableSize = _s.toFixed(digits) + ' ' +
-    ['B ', 'KB', 'MB', 'GB', 'TB'][power]
-
-  return humanReadableSize.padStart(FORMAT_SIZE_PAD)
-}
-
-/**
- * get size formatting function
- * @param {ListOptions} options
- * @param {BlockPaddings} paddings
- * @returns {BlockFormatter} formatting function
- */
-function getSizeFormatter (options, paddings) {
-  let formatter
-  if (options.size === 'bytes') {
-    const padStart = paddings.get('size')
-    formatter = (size) => size.toFixed(0).padStart(padStart)
-  } else {
-    formatter = formatSizeHumanReadable
-  }
-  if (options.color) {
-    return (item) => ct(formatter(item.size), 'FgYellow', 'Bright')
-  }
-  return (item) => formatter(item.size)
 }
 
 // mode

--- a/commands/list.js
+++ b/commands/list.js
@@ -328,17 +328,28 @@ function getModeFormatter (options) {
 }
 
 /**
+ * pad prop with spaces to length at the end
+ * @param {String} prop property to pad
+ * @param {BlockPaddings} paddings block paddings
+ * @returns {BlockFormatter} padEnd prop to length
+ */
+function padEnd (prop, paddings) {
+  const length = paddings.get(prop)
+  return item => item[prop].padEnd(length)
+}
+
+/**
  * get owner formatting function
  * @param {ListOptions} options list rendering options
  * @param {BlockPaddings} paddings block paddings
  * @returns {BlockFormatter} owner formatter
  */
 function getOwnerFormatter (options, paddings) {
-  const padStart = paddings.get('owner')
+  const padOwner = padEnd('owner', paddings)
   if (options.color) {
-    return (item) => ct(item.owner.padStart(padStart), 'FgWhite')
+    return (item) => ct(padOwner(item), 'FgWhite')
   }
-  return (item) => item.owner.padStart(padStart)
+  return padOwner
 }
 
 /**
@@ -348,11 +359,11 @@ function getOwnerFormatter (options, paddings) {
  * @returns {BlockFormatter} group formatter
  */
 function getGroupFormatter (options, paddings) {
-  const padStart = paddings.get('group')
+  const padGroup = padEnd('group', paddings)
   if (options.color) {
-    return (item) => ct(item.group.padStart(padStart), 'FgWhite')
+    return (item) => ct(padGroup(item), 'FgWhite')
   }
-  return (item) => item.group.padStart(padStart)
+  return padGroup
 }
 
 /**

--- a/commands/list.js
+++ b/commands/list.js
@@ -200,7 +200,7 @@ function getNameFormatter (options) {
 
 // path
 
-function noOp () {}
+const noOp = () => {}
 
 /**
  * render path colored

--- a/commands/list.js
+++ b/commands/list.js
@@ -5,7 +5,7 @@ import { getDateFormatter } from '../utility/colored-date.js'
 import { multiSort } from '../utility/sorter.js'
 import { recursivePadReducer } from '../utility/padding.js'
 import { getSizeFormatter } from '../utility/size.js'
-
+import { getGlobMatcher } from '../utility/glob.js'
 /**
  * @typedef { import("node-exist").NodeExist } NodeExist
  */
@@ -135,31 +135,6 @@ function getTreeFormatter (options) {
 }
 
 // name
-
-/**
- * transform globbing pattern to regular expression
- * @param {String} glob globbing pattern
- * @returns {String} regular expression
- */
-function toRegExpPattern (glob) {
-  const converted = glob
-    .replace(/\\/g, '\\\\') // escape backslashes
-    .replace(/\./g, '\\.') // make . literals
-    .replace(/\?/g, '.') // transform ?
-    .replace(/\*/g, '.*?') // transform *
-
-  return `^${converted}$`
-}
-
-/**
- * get filter function that checks item names against globbing pattern
- * @param {String} glob globbing pattern
- * @returns {(item:ListResultItem) => Boolean}
- */
-function getGlobMatcher (glob) {
-  const regex = new RegExp(toRegExpPattern(glob), 'i')
-  return (item) => regex.test(item.name)
-}
 
 /**
  * show displayName of item depending on its type

--- a/spec/tests/list.js
+++ b/spec/tests/list.js
@@ -119,7 +119,7 @@ test('with fixtures uploaded', async (t) => {
     st.end()
   })
 
-  t.test(`calling 'xst list ${testCollection} --tree --depth 2 --glob ".env"'`, async (st) => {
+  t.test(`calling 'xst list ${testCollection} --tree --depth 2 --glob .env'`, async (st) => {
     const { stderr, stdout } = await run('xst', ['list', testCollection, '--tree', '--depth', '2', '--glob', '.env'])
     if (stderr) st.fail(stderr)
     const expectedlines = [
@@ -129,7 +129,7 @@ test('with fixtures uploaded', async (t) => {
     ]
     const actualLines = stdout.split('\n')
     st.plan(expectedlines.length)
-    expectedlines.forEach((line, index) => st.ok(actualLines[index] === line, actualLines[index]))
+    expectedlines.forEach((line, index) => st.equal(actualLines[index], line, actualLines[index]))
     st.end()
   })
 

--- a/utility/glob.js
+++ b/utility/glob.js
@@ -1,0 +1,24 @@
+/**
+ * transform globbing pattern to regular expression
+ * @param {String} glob globbing pattern
+ * @returns {String} regular expression
+ */
+export function toRegExpPattern (glob) {
+  const converted = glob
+    .replace(/\\/g, '\\\\') // escape backslashes
+    .replace(/\./g, '\\.') // make . literals
+    .replace(/\?/g, '.') // transform ?
+    .replace(/\*/g, '.*?') // transform *
+
+  return `^${converted}$`
+}
+
+/**
+ * get filter function that checks item names against globbing pattern
+ * @param {String} glob globbing pattern
+ * @returns {(item:ListResultItem) => Boolean}
+ */
+export function getGlobMatcher (glob) {
+  const regex = new RegExp(toRegExpPattern(glob), 'i')
+  return (item) => regex.test(item.name)
+}

--- a/utility/padding.js
+++ b/utility/padding.js
@@ -6,6 +6,21 @@
  */
 
 /**
+ * measure length of atomic value
+ * @param {Number|String} value
+ * @returns {Number} length of value
+ */
+function measure (value) {
+  if (typeof value === 'number') {
+    return value.toFixed(0).length
+  }
+  if (typeof value === 'string') {
+    return value.length
+  }
+  throw TypeError('Cannot measure value length. Unsupported type: ' + typeof value)
+}
+
+/**
  * Get maximum needed paddings for properties
  * Only properties that are part of initial paddings keys
  * will be checked
@@ -15,8 +30,9 @@
  */
 export function padReducer (paddings, next) {
   for (const key of paddings.keys()) {
-    if (paddings.get(key) < next[key].length) {
-      paddings.set(key, next[key].length)
+    const length = measure(next[key])
+    if (paddings.get(key) < length) {
+      paddings.set(key, length)
     }
   }
   return paddings
@@ -33,6 +49,7 @@ export function padReducer (paddings, next) {
 export function recursivePadReducer (treeProperty) {
   const descendantAccessor = (item) => item[treeProperty]
   /**
+   * named function to allow recursion
    * @param {BlockPaddings} paddings
    * @param {Object} next next item to check
    * @returns {BlockPaddings} actual paddings

--- a/utility/size.js
+++ b/utility/size.js
@@ -1,0 +1,73 @@
+import { ct } from './console.js'
+
+/**
+ * @typedef {(item:ListResultItem) => String} BlockFormatter
+ */
+/**
+ * @typedef {Object} OptionsWithSize
+ * @prop {"human"|"bytes"} size size format
+ */
+/**
+ * @typedef {import('./padding.js').BlockPaddings} BlockPaddings
+ */
+
+const FORMAT_SIZE_BASE = 1024
+const FORMAT_SIZE_PAD = 7
+
+/**
+ * convert raw bytes to humand readable size string
+ * @param {Number} size bytes
+ * @returns {String} human readable size
+ */
+function formatSizeHumanReadable (size) {
+  if (size === 0) {
+    return '0 B '.padStart(FORMAT_SIZE_PAD)
+  }
+  const power = Math.floor(Math.log(size) / Math.log(FORMAT_SIZE_BASE))
+  const _s = size / Math.pow(FORMAT_SIZE_BASE, power)
+  const _p = Math.floor(Math.log(_s) / Math.log(10))
+  const digits = _p < 2 ? 1 : 0
+  const humanReadableSize = _s.toFixed(digits) + ' ' +
+        ['B ', 'KB', 'MB', 'GB', 'TB'][power]
+
+  return humanReadableSize.padStart(FORMAT_SIZE_PAD)
+}
+
+/**
+ * pad raw bytes to match longest size
+ * @param {Number} size bytes
+ * @param {BlockPaddings} paddings padding map
+ * @returns {(size:Number) => String} formatting function
+ */
+function byteFormatter (paddings) {
+  const padStart = paddings.get('size')
+  return (size) => size.toFixed(0).padStart(padStart)
+}
+
+/**
+ * get size formatting function
+ * @param {OptionsWithSize} options
+ * @param {BlockPaddings} paddings
+ * @returns {BlockFormatter} formatting function
+ */
+export function getSizeFormatter (options, paddings) {
+  const formatter = options.size === 'bytes'
+    ? byteFormatter(paddings)
+    : formatSizeHumanReadable
+
+  if (options.color) {
+    return (item) => ct(formatter(item.size), 'FgYellow', 'Bright')
+  }
+  return (item) => formatter(item.size)
+}
+
+/**
+ * yargs option definition for the size parameter
+ */
+export const sizeOption = {
+  size: {
+    describe: 'How to display resource size',
+    choices: ['short', 'bytes'],
+    default: 'short'
+  }
+}

--- a/utility/tree.js
+++ b/utility/tree.js
@@ -1,0 +1,58 @@
+// tree
+
+/**
+ * @typedef {(item:T, indent:String, last:Boolean, level:Number) => String} TreeItemRenderer<T>
+ * @template T
+ */
+
+/**
+ * @typedef {(item:T) => string} BlockFormatter<T>
+ * @template T
+ */
+
+const FILL = '│   '
+const ITEM = '├── '
+const LAST = '└── '
+const EMPTY = '    '
+
+/**
+ * get part for current position in tree
+ * @param {String} indent current indent
+ * @param {Boolean} last is this the last element in this branch
+ * @param {Number} level the current level
+ * @returns {String} tree part
+ */
+function getTreeForItem (indent, last, level) {
+  if (level === 0) {
+    return ''
+  }
+  if (last) {
+    return indent + LAST
+  }
+  return indent + ITEM
+}
+
+/**
+ * shift indent for nested lists
+ * @param {String} indent current indent
+ * @param {Boolean} last is the current item the last one
+ * @returns {String} next indent
+ */
+export function getNextIndent (indent, last) {
+  if (last) {
+    return indent + EMPTY
+  }
+  return indent + FILL
+}
+
+/**
+ * get tree formatter for type T
+ * @param {BlockFormatter<T>} itemFormatter render item after tree
+ * @returns {TreeItemRenderer<T>} render tree item
+ * @template T item type
+ */
+export function getTreeFormatter (itemFormatter) {
+  return function (item, indent, last, level) {
+    return getTreeForItem(indent, last, level) + itemFormatter(item)
+  }
+}


### PR DESCRIPTION
- owner and group left-aligned: implements  variant C of #63
- fix alignment of size block for `--size bytes`
- extract glob matching, size and tree formatting into separate modules for re-use, testability and readability 