### PR TITLE
fix: consolidate command descriptions, order

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -45,11 +45,10 @@ function showLogo () {
 }
 
 const parser = yargs(hideBin(process.argv))
-  .config('config', 'configuration to use', configure)
+  .config('config', 'Read configuration file', configure)
   .middleware(readConnection)
-  .command('$0', 'interact with an exist-db instance', () => {}, async (argv) => {
+  .command('$0 [<command>]', 'Interact with an eXist-db', () => {}, async (argv) => {
     showLogo()
-    // console.log(await parser.getHelp())
     const scriptName = getScriptName(argv.$0)
     showCompletionHelp(scriptName)
     // append examples

--- a/commands/exec.js
+++ b/commands/exec.js
@@ -77,7 +77,7 @@ async function execute (db, query, variables) {
 }
 
 export const command = ['execute [<query>] [options]', 'run', 'exec']
-export const describe = 'execute a query in an exist-db instance'
+export const describe = 'Execute a query string or file'
 
 export async function builder (yargs) {
   yargs

--- a/commands/get.js
+++ b/commands/get.js
@@ -267,7 +267,7 @@ async function downloadCollectionOrResource (db, source, target, options) {
 }
 
 export const command = ['get [options] <source> <target>', 'download', 'fetch']
-export const describe = 'Download a collection or resources from exist-db'
+export const describe = 'Download a collection or resource'
 
 export function builder (yargs) {
   yargs
@@ -292,7 +292,7 @@ export function builder (yargs) {
     .option('N', {
       group: 'serialization',
       alias: 'insert-final-newline',
-      describe: 'Force a final newline at the end of an XMLResource',
+      describe: 'Force a final newline at the end of an XMLResource (requires eXist >=6.1.0)',
       ...xmlBooleanSetting
     })
     .option('v', {

--- a/commands/index.js
+++ b/commands/index.js
@@ -7,11 +7,11 @@ import * as rm from './rm.js'
 import * as upload from './upload.js'
 
 export const commands = [
-  exec,
-  get,
   info,
-  list,
-  pkg,
+  get,
+  upload,
   rm,
-  upload
+  exec,
+  list,
+  pkg
 ]

--- a/commands/info.js
+++ b/commands/info.js
@@ -25,7 +25,7 @@ async function info (db, options) {
 }
 
 export const command = ['info']
-export const describe = 'gather information on connected the instance'
+export const describe = 'Gather system information'
 
 /**
  * handle info command

--- a/commands/list.js
+++ b/commands/list.js
@@ -496,7 +496,7 @@ async function ls (db, collection, options) {
 }
 
 export const command = ['list [options] <collection>', 'ls']
-export const describe = 'List connection contents'
+export const describe = 'List collection contents'
 
 const options = {
   G: {

--- a/commands/package/index.js
+++ b/commands/package/index.js
@@ -7,7 +7,7 @@ const commands = [
 ]
 
 export const command = ['package <command>', 'pkg']
-export const describe = 'do something with packages'
+export const describe = 'Work with packages'
 export async function handler (argv) {
   if (argv.help) {
     return 0

--- a/commands/package/install.js
+++ b/commands/package/install.js
@@ -52,7 +52,7 @@ async function install (db, localFilePath) {
 }
 
 export const command = ['install [options] <packages..>', 'i']
-export const describe = 'Install XAR package'
+export const describe = 'Install XAR packages'
 
 export async function handler (argv) {
   if (argv.help) {

--- a/commands/rm.js
+++ b/commands/rm.js
@@ -86,7 +86,7 @@ async function rm (db, paths, options) {
 }
 
 export const command = ['remove [options] <paths..>', 'rm', 'delete', 'del']
-export const describe = 'remove collections and resources'
+export const describe = 'Remove collections or resources'
 
 const options = {
   // g: {

--- a/commands/upload.js
+++ b/commands/upload.js
@@ -212,7 +212,7 @@ async function uploadFileOrFolder (db, source, target, options) {
 }
 
 export const command = ['upload [options] <source> <target>', 'up']
-export const describe = 'Upload files and directories to a target collection in exist-db'
+export const describe = 'Upload files and directories'
 
 export function builder (yargs) {
   yargs

--- a/readme.md
+++ b/readme.md
@@ -42,22 +42,23 @@ xst <command> --help
 
 **Available Commands**
 
-- `info` show system information of the connected database
-- `list` list the contents of a collection
-- `upload` upload files and folders to a collection
-- `get` download a collection or resource to the filesystem
-- `rm` remove collections and resources
-- `package` package related commands
-  - `install` upload and install a local XAR package
-  - `list` list installed packages
-- `execute` the swiss army knife command that lets you query data or run a main module
+|command|description|aliases|
+|--|--|--|
+|`info`|Gather system information| |
+|`get [options] <source> <target>`|Download a collection or resource|`download` `fetch`|
+|`upload [options] <source> <target>`|Upload files and directories|`up`|
+|`remove [options] <paths..>`|Remove collections or resources|`rm` `delete` `del`|
+|`execute [<query>] [options]`|Execute a query string or file|`run` `exec`|
+|`list [options] <collection>`|List collection contents|`ls`|
+|`package install [options] <packages..>`|Install XAR packages|`pkg i`|
+|`package list [options]`|List installed packages|`pkg ls`|
 
 ### Examples
 
 #### List collections
 
 ```bash
-xst ls /db
+xst list /db
 ```
 
 #### List the entire contents of the apps collection
@@ -65,7 +66,7 @@ xst ls /db
 This will output extended and colored information of all collections and resources of `/db/apps` in a tree.
 
 ```bash
-xst ls /db/apps --long --tree --color
+xst list /db/apps --long --tree --color
 ```
 
 **NOTE:** Resources and collections the connecting user does not have access to will be omitted with --long.
@@ -73,7 +74,7 @@ xst ls /db/apps --long --tree --color
 #### Find the largest JavaScript resource
 
 ```bash
-xst ls /db/apps --long --recursive --color --glob '*.js' --sizesort
+xst list /db/apps --long --recursive --color --glob '*.js' --sizesort
 ```
 
 #### Download a resource 
@@ -103,14 +104,14 @@ scripts. You need to connnect as a database administrator to be able to run the
 queries.
 
 ```bash
-xst run 'sm:chmod(xs:anyURI($file), $permissions)' \
+xst execute 'sm:chmod(xs:anyURI($file), $permissions)' \
   -b '{"file": "/db/apps/dashboard/controller.xql", "permissions": "rwxrwxr-x"}'
 ```
 
 Reset the permissions back to their original state.
 
 ```bash
-xst run 'sm:chmod(xs:anyURI($file), $permissions)' \
+xst execute 'sm:chmod(xs:anyURI($file), $permissions)' \
   -b '{"file": "/db/apps/dashboard/controller.xql", "permissions": "rwxr-xr-x"}'
 ```
 
@@ -120,7 +121,7 @@ If you find yourself using the same query over and over again or it is a complex
 you can save it to a file and use the `--file` parameter.
 
 ```bash
-xst run --file my-query.xq
+xst execute --file my-query.xq
 ```
 
 #### Install a local XAR package into an exist-db.


### PR DESCRIPTION
- always start with a capital character
- remove redundant information (~instance)
- fix wording (connection -> collection)
- re-order and group commands
- display commands in table with aliases
- use main command in examples instead of aliases

Preview of readme after changes https://github.com/eXist-db/xst/blob/f5ab970b720562c053f3cd68503cc441cb66962b/readme.md

Thanks to valuable feedback from @JoernT and Pieter