### PR TITLE
Feat: raw info

### DIFF
--- a/commands/info.js
+++ b/commands/info.js
@@ -12,16 +12,27 @@ const query = readXquery('info.xq')
 
 async function info (db, options) {
   const result = await db.queries.readAll(query, {})
-  const json = JSON.parse(result.pages.toString())
+  const raw = result.pages.toString()
+  const json = JSON.parse(raw)
+
   if (json.error) {
+    if (options.raw) {
+      console.error(raw)
+      return 1
+    }
     if (options.debug) {
       console.error(json.error)
     }
     throw Error(json.error.description)
   }
+  if (options.raw) {
+    console.log(raw)
+    return 0
+  }
   console.log(`Build: ${json.db.name}-${json.db.version} (${json.db.git})`)
   console.log(`Java: ${json.java.version} (${json.java.vendor})`)
   console.log(`OS: ${json.os.name} ${json.os.version} (${json.os.arch})`)
+  return 0
 }
 
 export const command = ['info']

--- a/spec/tests/info.js
+++ b/spec/tests/info.js
@@ -12,3 +12,27 @@ test("calling 'xst info'", async (t) => {
   t.ok(lines[1].startsWith('Java: '), 'has Java info')
   t.ok(lines[2].startsWith('OS: '), 'has OS info')
 })
+
+test("calling 'xst info --raw' returns valid JSON", async (t) => {
+  try {
+    const { stderr, stdout } = await run('xst', ['info', '--raw'], asAdmin)
+    if (stderr) { return t.fail(stderr) }
+    const { db, java, os } = JSON.parse(stdout)
+    t.plan(11)
+    t.ok(db, 'outputs build information')
+    t.ok(db.name, 'outputs DB name')
+    t.ok(db.version, 'outputs DB version')
+    t.ok(db.git, 'outputs git hash')
+
+    t.ok(java, 'outputs jvm information')
+    t.ok(java.vendor, 'outputs java vendor')
+    t.ok(java.version, 'outputs java version')
+
+    t.ok(os, 'outputs operating system information')
+    t.ok(os.name, 'outputs OS name')
+    t.ok(os.version, 'outputs OS version')
+    t.ok(os.arch, 'outputs CPU architecture')
+  } catch (e) {
+    t.fail(e, 'invalid JSON returned')
+  }
+})

--- a/spec/tests/list.js
+++ b/spec/tests/list.js
@@ -294,9 +294,9 @@ test('with fixtures uploaded', async (t) => {
 /db/list-test/fixtures/broken-test-app.xar
 /db/list-test/fixtures/test.xml
 /db/list-test/tests
-/db/list-test/tests/info.js
 /db/list-test/tests/cli.js
 /db/list-test/tests/upload.js
+/db/list-test/tests/info.js
 /db/list-test/tests/configuration.js
 /db/list-test/tests/exec.js
 /db/list-test/tests/rm.js


### PR DESCRIPTION
Add --raw option to the info command.

```zsh
xst info --raw 
```

will output something along the lines of

```json
{
  "db": {
    "name": "eXist",
    "version": "6.2.0-SNAPSHOT",
    "git": "ac2c7e17867013bb9aac76f3413ee837f540550b"
  },
  "java": {
    "vendor": "Azul Systems, Inc.",
    "version": "1.8.0_362"
  },
  "os": {
    "name": "Mac OS X",
    "version": "12.6.2",
    "arch": "aarch64"
  }
}
```