### PR TITLE
feat: add edit command

### DIFF
--- a/commands/edit.js
+++ b/commands/edit.js
@@ -1,0 +1,153 @@
+// import open from 'open-editor'
+import { resolve, basename } from 'node:path'
+import {
+  writeFileSync, readFileSync,
+  watchFile, unwatchFile,
+  statSync, unlinkSync
+} from 'node:fs'
+import * as readline from 'node:readline'
+
+import chalk from 'chalk'
+import execa from 'execa'
+import { getEditor } from 'env-editor'
+import { connect } from '@existdb/node-exist'
+
+/**
+ * @typedef { import("@existdb/node-exist").NodeExist } NodeExist
+ */
+/**
+ * @typedef { import("env-editor").Editor } Editor
+ */
+
+/**
+ *
+ * @param {Editor} editor
+ * @param {Array} args
+ * @param {Function} cb
+ * @returns {Promise}
+ */
+async function openEditor (editor, args, cb) {
+  const stdio = editor.isTerminalEditor ? 'inherit' : 'ignore'
+  const subprocess = execa(editor.binary, args, { detached: true, stdio })
+  return new Promise((resolve, reject) => {
+    subprocess.on('exit', async _ => resolve(await cb()))
+    subprocess.on('error', error => reject(error))
+  })
+}
+
+/**
+ * query db, output to standard out
+ *
+ * @param {NodeExist} db NodeExist client
+ * @param {string} resource db path
+ * @param {Editor} editor identified editor
+ * @returns {Number}
+ */
+async function edit (db, resource, editor) {
+  try {
+    const info = await db.resources.describe(resource)
+    // console.log(info, editor)
+    let fileContents
+    if (info.type === 'BinaryResource') {
+      console.log('read binary')
+      fileContents = await db.documents.readBinary(resource)
+    } else {
+      // get XML with default serialization
+      console.log('read XML')
+      fileContents = await db.documents.read(resource, {})
+    }
+    const resourceName = basename(resource)
+    const tempFile = resolve('./~xst-edit~' + resourceName)
+    await writeFileSync(tempFile, fileContents)
+    const init = await statSync(tempFile)
+
+    // watch for changes while editor is running
+    watchFile(tempFile, async (curr, prev) => {
+      if (curr.mtime === prev.mtime) {
+        return console.log('unchanged')
+      }
+      const newFileContents = readFileSync(tempFile)
+      const fileHandle = await db.documents.upload(newFileContents)
+      const uploadResult = await db.documents.parseLocal(fileHandle, resource, null)
+      if (!editor.isTerminalEditor) {
+        console.log('upload: ', uploadResult)
+      }
+    })
+
+    let cb = () => {
+      console.log(`Stop watching file with ${chalk.yellow('q')} or ${chalk.yellow('ctrl+c')}`)
+      readline.emitKeypressEvents(process.stdin)
+      if (process.stdin.isTTY) { process.stdin.setRawMode(true) }
+      const abort = (resolve, reject) => {
+        process.stdin.on('keypress', (ch, key) => {
+          if (key && (key.name === 'q' || (key.ctrl && key.name === 'c'))) {
+            unwatchFile(tempFile)
+            unlinkSync(tempFile)
+            process.stdin.pause()
+            console.log('stopped watching, temporary file removed')
+            resolve(0)
+          }
+        })
+      }
+      return new Promise(abort)
+    }
+
+    if (editor.isTerminalEditor) {
+      cb = async () => {
+        const curr = await statSync(tempFile)
+        const unchanged = curr.mtime.getTime() === init.mtime.getTime()
+        if (unchanged) {
+          console.log('unchanged')
+        } else {
+          const newFileContents = readFileSync(tempFile)
+          const fileHandle = await db.documents.upload(newFileContents)
+          const uploadResult = await db.documents.parseLocal(fileHandle, resource, {})
+          console.log('upload: ', uploadResult)
+        }
+
+        // unwatch because editor was closed
+        unwatchFile(tempFile)
+        unlinkSync(tempFile)
+        console.log('stopped watching, temporary file removed')
+      }
+    }
+
+    await openEditor(editor, [tempFile], cb)
+    return 0
+  } catch (e) {
+    console.error(e)
+    return 1
+  }
+}
+
+function coerceEditor (id) {
+  if (!id || id === '') {
+    throw Error('No editor specified. Set with --editor or $EDITOR')
+  }
+  const editor = getEditor(id)
+  if (!editor) {
+    throw Error('No editor found with id', id)
+  }
+  console.log('opening resource with ', editor.id)
+  return editor
+}
+
+export const command = ['edit <resource>']
+export const describe = 'Edit a resource in an editor'
+
+export function builder (yargs) {
+  yargs
+    .option('editor', {
+      describe: 'The editor to open the resource with, defaults to $EDITOR',
+      default: process.env.EDITOR,
+      coerce: coerceEditor
+    })
+}
+
+export async function handler (argv) {
+  if (argv.help) {
+    return 0
+  }
+  const { resource, connectionOptions, editor } = argv
+  return await edit(connect(connectionOptions), resource, editor)
+}

--- a/commands/index.js
+++ b/commands/index.js
@@ -1,3 +1,4 @@
+import * as edit from './edit.js'
 import * as exec from './exec.js'
 import * as get from './get.js'
 import * as info from './info.js'
@@ -11,6 +12,7 @@ export const commands = [
   get,
   upload,
   rm,
+  edit,
   exec,
   list,
   pkg

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@existdb/node-exist": "^5.4.0",
         "bottleneck": "^2.19.5",
         "dotenv": "^16.0.3",
+        "env-editor": "^1.1.0",
         "fast-glob": "^3.2.12",
         "semver": "^7.3.8",
         "yargs": "^17.6.2"
@@ -2196,6 +2197,17 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/env-editor": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/env-editor/-/env-editor-1.1.0.tgz",
+      "integrity": "sha512-7AXskzN6T7Q9TFcKAGJprUbpQa4i1VsAetO9rdBqbGMGlragTziBgWt4pVYJMBWHQlLoX0buy6WFikzPH4Qjpw==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -11456,6 +11468,11 @@
           "dev": true
         }
       }
+    },
+    "env-editor": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/env-editor/-/env-editor-1.1.0.tgz",
+      "integrity": "sha512-7AXskzN6T7Q9TFcKAGJprUbpQa4i1VsAetO9rdBqbGMGlragTziBgWt4pVYJMBWHQlLoX0buy6WFikzPH4Qjpw=="
     },
     "error-ex": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@existdb/node-exist": "^5.4.0",
     "bottleneck": "^2.19.5",
     "dotenv": "^16.0.3",
+    "env-editor": "^1.1.0",
     "fast-glob": "^3.2.12",
     "semver": "^7.3.8",
     "yargs": "^17.6.2"


### PR DESCRIPTION
closes #8

Example:
`xst edit /db/apps/my-app/resource.xml --editor vim`

Alternatively, you can set $EDITOR environment variable or specify it in the configuration file (xstrc).
At the moment, the value can be an executable or keywords recognized by env-editor.

Works with visual editors as well as long as the provide a command line launcher (tested with VSCode, intellij IDEA).