### PR TITLE
list command compatible with newer versions of exist-db

### DIFF
--- a/commands/list.js
+++ b/commands/list.js
@@ -433,15 +433,17 @@ function getListRenderer (options, renderItem, sortItemList) {
  */
 async function ls (db, collection, options) {
   const { glob, long, tree, recursive, depth } = options
-  const result = await db.queries.readAll(query, {
-    variables: {
-      collection,
-      glob,
-      depth,
-      recursive: tree || recursive,
-      'collections-only': options['collections-only']
-    }
-  })
+  const variables = {
+    collection,
+    glob,
+    depth,
+    recursive: Boolean(tree || recursive),
+    'collections-only': options['collections-only']
+  }
+  if (options.debug) {
+    console.log(variables)
+  }
+  const result = await db.queries.readAll(query, { variables })
   const raw = result.pages.toString()
   const json = JSON.parse(raw)
   if (json.error) {

--- a/modules/list-resources.xq
+++ b/modules/list-resources.xq
@@ -124,7 +124,7 @@ declare function local:get-children ($collection as xs:string, $current-level as
 };
 
 declare function local:list ($collection as xs:string, $options as map(*)) as map(*) {
-    let $normalized-collection := replace($collection, "^(.*?)/?$", "$1")
+    let $normalized-collection := replace($collection, "^(.+?)/?$", "$1")
     let $parent-collection := replace($normalized-collection, "(/[^/]+)$", "")
     let $collection-name := replace($normalized-collection, "^(.*?/)([^/]+)$", "$2")
     return


### PR DESCRIPTION
- In newer versions of exist-db the regular expressions are checked
  if they might match the empty string and raise an error if they do.
  This resulted in all calls to `xst list` to fail.

- The recursive variable bound to the query was undefined when both
   the tree and the recursive option were not set.
   Since these are conflicting, they cannot be assigned a default value.