### PR TITLE
feat(package): package upload uses REST by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
-        "@existdb/node-exist": "^5.4.0",
+        "@existdb/node-exist": "^5.4.1",
         "bottleneck": "^2.19.5",
         "chalk": "^5.2.0",
         "dotenv": "^16.0.3",
@@ -897,9 +897,9 @@
       }
     },
     "node_modules/@existdb/node-exist": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@existdb/node-exist/-/node-exist-5.4.0.tgz",
-      "integrity": "sha512-4vIqb2PztUH7BFJf8ro0oCHWKsg/qkk/4AMrwZH7C5v9tZWLEBL9ieu5/r73vzzC4bSXRAmPqOXwQpVetOP5Xw==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@existdb/node-exist/-/node-exist-5.4.1.tgz",
+      "integrity": "sha512-8Ws6LanpxAMZ1GpyUX5CWfa90kikp38VZvhkmYBdpFFUuuqbCNvLb5nUswJH2ZtTAjp0uN1t7zbaqairIO2hyQ==",
       "dependencies": {
         "got": "^12.1.0",
         "lodash.assign": "^4.0.2",
@@ -12381,9 +12381,9 @@
       "dev": true
     },
     "@existdb/node-exist": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@existdb/node-exist/-/node-exist-5.4.0.tgz",
-      "integrity": "sha512-4vIqb2PztUH7BFJf8ro0oCHWKsg/qkk/4AMrwZH7C5v9tZWLEBL9ieu5/r73vzzC4bSXRAmPqOXwQpVetOP5Xw==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@existdb/node-exist/-/node-exist-5.4.1.tgz",
+      "integrity": "sha512-8Ws6LanpxAMZ1GpyUX5CWfa90kikp38VZvhkmYBdpFFUuuqbCNvLb5nUswJH2ZtTAjp0uN1t7zbaqairIO2hyQ==",
       "requires": {
         "got": "^12.1.0",
         "lodash.assign": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "maintainers": [],
   "license": "MIT",
   "dependencies": {
-    "@existdb/node-exist": "^5.4.0",
+    "@existdb/node-exist": "^5.4.1",
     "bottleneck": "^2.19.5",
     "chalk": "^5.2.0",
     "dotenv": "^16.0.3",

--- a/spec/tests/package/install.js
+++ b/spec/tests/package/install.js
@@ -41,7 +41,7 @@ test('shows help', async function (t) {
   if (stderr) { return t.fail(stderr) }
   t.ok(stdout, 'got output')
   const firstLine = stdout.split('\n')[0]
-  t.equal(firstLine, 'xst package install [options] <packages..>', firstLine)
+  t.equal(firstLine, 'xst package install <packages..>', firstLine)
 })
 
 test('fails when dependency is not met', async function (t) {
@@ -150,6 +150,29 @@ test('multiple valid packages', async function (t) {
     if (stdout) { return st.fail(stdout) }
 
     st.equal(stderr, `Collection "${packageCollection}" not found!\n`)
+  })
+
+  t.teardown(cleanup)
+})
+
+test('using rest for upload', async function (t) {
+  t.test('installs lib first', async function (st) {
+    const { stderr, stdout } = await run('xst', ['package', 'install', '--rest', 'spec/fixtures/test-lib.xar'], asAdmin)
+    if (stderr) {
+      // console.error(stderr)
+      st.fail(stderr)
+      return st.end()
+    }
+    st.ok(stdout)
+  })
+  t.test('installs app', async function (st) {
+    const { stderr, stdout } = await run('xst', ['package', 'install', '--rest', 'spec/fixtures/test-app.xar'], asAdmin)
+    if (stderr) {
+      // console.error(stderr)
+      st.fail(stderr)
+      return st.end()
+    }
+    st.ok(stdout)
   })
 
   t.teardown(cleanup)

--- a/utility/configure.js
+++ b/utility/configure.js
@@ -56,6 +56,7 @@ function compileConnectionOptions (server, user, pass) {
     connectionOptions.secure = protocol === 'https:'
     connectionOptions.host = hostname
     connectionOptions.port = port
+    connectionOptions.protocol = protocol
   }
 
   return { connectionOptions }


### PR DESCRIPTION
fixes #5

`xst package install <packages..>` will now use exist-db's REST API by default and will fallback to XML-RPC only if REST is not available. This allows uploads of XAR packages larger than 500MB.

Setting `--rest` will _force_ uploads to use the  REST endpoint and installation wil fail when it is deactivated on the target instance.

Setting `--xmlrpc` or `--rpc` on the other hand will always use XML-RPC but limits the size of installable XARs.