### PR TITLE
fix(package): installation falls back to XMLRPC

### DIFF
--- a/.github/workflows/test-no-rest.yml
+++ b/.github/workflows/test-no-rest.yml
@@ -1,0 +1,41 @@
+name: Test - No REST
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # pull image 
+      - run: docker pull existdb/existdb:release
+      # create docker container
+      # --volume $(pwd)/empty:/exist/autodeploy:ro
+      - name: create eXist-db Container
+        run: docker create --name exist --publish 8080:8080 --publish 8443:8443 existdb/existdb:release
+      # - name: Start eXist-db Container
+      #   run: docker start exist
+      # - name: Wait for eXist-db Startup
+      #   run: timeout 90 sh -c 'until nc -z $0 $1; do sleep 3; done' localhost 8080
+      # get web.xml (use prepared web.xml instead)
+      # - run: docker cp exist:exist/etc/webapp/WEB-INF/web.xml ./web.xml
+      # modify web.xml
+      # - run: cat web.xml | \
+          # tr '\n' '\r' | \
+          # sed -E 's/(<param-name>hidden<\/param-name>\r[[:space:]]+<param-value>)false(<\/param-value>)/\1true\2/' | \
+          # tr '\r' '\n' > modified-web.xml
+      - name: Copy modified web.xml
+        run: docker cp ./spec/fixtures/web-no-rest.xml exist:exist/etc/webapp/WEB-INF/web.xml
+      - name: Restart eXist-db Container
+        # run: docker stop exist && docker wait; docker start exist
+        run: docker start exist
+      - name: Wait for eXist-db Startup
+        run: timeout 90 sh -c 'until nc -z $0 $1; do sleep 3; done' localhost 8080
+      - name: Use Node.js 20
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - run: npm ci --no-optional
+      - run: npm link
+      - run: npm run test:norest
+

--- a/commands/package/install.js
+++ b/commands/package/install.js
@@ -108,8 +108,13 @@ export async function handler (argv) {
     if (rest) {
       upload = boundUpload
     } else {
-      const test = await restClient.get('db')
-      upload = test.statusCode === 200 ? boundUpload : db.app.upload
+      try {
+        await restClient.get('db')
+        upload = boundUpload
+      } catch (e) {
+        console.log('Falling back to XMLRPC API')
+        upload = db.app.upload
+      }
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "scripts": {
     "test": "standard && tape \"spec/tests/**/*.js\"",
+    "test:norest": "tape \"spec/norest/**/*.js\"",
     "lint": "standard --fix"
   },
   "keywords": [

--- a/spec/fixtures/web-no-rest.xml
+++ b/spec/fixtures/web-no-rest.xml
@@ -1,0 +1,409 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--+
+    | Configuration file for the web application.
+    |
+    | The URL mapping for rest, xmlrpc, soap etc are handled now by the
+    | XQueryURLRewrite servlet filter. See for details below.
+    +-->
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         metadata-complete="false"
+         version="3.1">
+   <description>eXist Open Source Native XML Database</description>
+   <display-name>eXist XML Database</display-name>
+   <!--
+	 | ScaleImageJAI servlet: scale images on the fly and cache
+	 | the output. Commented out by default.
+	 +-->
+   <!--
+    <servlet>
+        <servlet-name>ScaleImageJAI</servlet-name>
+        <servlet-class>org.exist.http.servlets.ScaleImageJAI</servlet-class>
+
+        <init-param>
+            <param-name>base</param-name>
+            <param-value>xmldb:exist:///db</param-value>
+        </init-param>
+
+        <init-param>
+            <param-name>output-dir</param-name>
+            <param-value>/home/wolf/images</param-value>
+        </init-param>
+    </servlet>
+    -->
+   <!--
+        RpcServlet provides XML-RPC access.
+    -->
+   <servlet>
+      <servlet-name>org.exist.xmlrpc.RpcServlet</servlet-name>
+      <servlet-class>org.exist.xmlrpc.RpcServlet</servlet-class>
+      <init-param>
+         <param-name>enabledForExtensions</param-name>
+         <param-value>true</param-value>
+      </init-param>
+      <init-param>
+            <!--
+            When no user is specified in an XML-RPC request,
+            the guest user account will be used.
+
+            When useDefaultUser is set to false, the guest user
+            is prohibited from accessing the XML-RPC API.
+            -->
+         <param-name>useDefaultUser</param-name>
+         <param-value>true</param-value>
+      </init-param>
+      <init-param>
+            <!--
+            The Apache XML-RPC servlet does not set a charset
+            in the HTTP response, so the default HTTP charset
+            of ISO-8859-1 is implied.
+
+            We override that to make the default UTF-8 here.
+            You may choose any charset supported by
+            java.nio.charset.Charset
+            -->
+         <param-name>charset</param-name>
+         <param-value>UTF-8</param-value>
+      </init-param>
+   </servlet>
+   <!--
+        EXistServlet is a helper servlet that is used to ensure that
+        eXist is running in the background.
+        Set the start-parameter to true and load-on-startup a low value e.g. 2.
+    -->
+   <servlet>
+      <servlet-name>EXistServlet</servlet-name>
+      <servlet-class>org.exist.http.servlets.EXistServlet</servlet-class>
+      <!--
+            Location of eXist's configuration file relative to the basedir
+            of the web-application.
+        -->
+      <init-param>
+         <param-name>configuration</param-name>
+         <param-value>conf.xml</param-value>
+      </init-param>
+      <!--
+            eXist's home directory. All file names in the configuration file
+            will be relative to this directory.
+        -->
+      <init-param>
+         <param-name>basedir</param-name>
+         <param-value>WEB-INF/</param-value>
+      </init-param>
+      <init-param>
+         <param-name>start</param-name>
+         <param-value>true</param-value>
+      </init-param>
+      <!--
+			If parameter "hidden" is set to true, direct access to the
+			REST interface will be denied. Only requests coming from the
+			URL rewriting will be processed.
+
+			Rationale: on a production server, you may want to store the
+			application within the database, but without allowing users
+			to browse the database contents. By setting hidden=true, you
+			can expose defined URLs to the outside world via URL rewriting
+			while hiding the rest of the database.
+		-->
+      <init-param>
+         <param-name>hidden</param-name>
+         <param-value>true</param-value>
+      </init-param>
+      <!--
+            Determines who is allowed to submit XQuery to the servlet
+            and have it executed.
+
+            For example the RESTServer allows submission via the
+            GET query parameter _query, and
+            POST via an XML document with a <query> document element
+
+            - disabled
+                Does not allow anyone to submit XQuery for execution
+
+            - enabled
+                Allows anyone to submit XQuery for execution
+
+            - authenticated
+                Allows any authenticated (non-guest) user to submit
+                XQuery for execution
+        -->
+      <init-param>
+         <param-name>xquery-submission</param-name>
+         <param-value>enabled</param-value>
+      </init-param>
+      <!--
+            Determines who is allowed to submit XUpdate to the servlet
+            and have it executed.
+
+            For example the RESTServer allows submission via
+            POST of an XML XUpdate document
+
+            - disabled
+                Does not allow anyone to submit XUpdate for execution
+
+            - enabled
+                Allows anyone to submit XUpdate for execution
+
+            - authenticated
+                Allows any authenticated (non-guest) user to submit
+                XUpdate for execution
+        -->
+      <init-param>
+         <param-name>xupdate-submission</param-name>
+         <param-value>enabled</param-value>
+      </init-param>
+      <load-on-startup>2</load-on-startup>
+   </servlet>
+   <!--
+        JMXservlet is a servlet to monitor the database. It returns status information 
+        for the database based on the JMX interface.
+    -->
+   <servlet>
+      <servlet-name>JMXServlet</servlet-name>
+      <servlet-class>org.exist.management.client.JMXServlet</servlet-class>
+   </servlet>
+   <!--
+            Milton provides the WebDAV interface
+   -->
+   <servlet>
+      <servlet-name>milton</servlet-name>
+      <servlet-class>org.exist.webdav.MiltonWebDAVServlet</servlet-class>
+      <init-param>
+         <param-name>resource.factory.class</param-name>
+         <param-value>org.exist.webdav.ExistResourceFactory</param-value>
+      </init-param>
+      <!--
+                Some WebDAV clients send a "Expect: 100-continue" header before 
+                uploading body data. Servlet containers (like tomcat and jetty) handle 
+                the header in a wrong way, making a client not work OK.
+                Set value to TRUE to restore old behavior (FALSE is the new default 
+                value, hardcoded in MiltonWebDAVServlet).       
+            -->
+      <!-- <init-param>
+         <param-name>enable.expect.continue</param-name>
+         <param-value>false</param-value>
+      </init-param>
+      -->    
+    <!--
+                Uncomment to enable debugging
+            -->
+      <!-- <init-param>
+         <param-name>filter_0</param-name>
+         <param-value>com.bradmcevoy.http.DebugFilter</param-value>
+      </init-param>
+      -->
+    </servlet>
+   <!--
+        XQueryServlet generates HTML from an XQuery file.
+    -->
+   <servlet>
+      <servlet-name>XQueryServlet</servlet-name>
+      <servlet-class>org.exist.http.servlets.XQueryServlet</servlet-class>
+      <init-param>
+         <param-name>uri</param-name>
+         <param-value>xmldb:exist:///db</param-value>
+      </init-param>
+      <init-param>
+         <param-name>form-encoding</param-name>
+         <param-value>UTF-8</param-value>
+      </init-param>
+      <init-param>
+         <param-name>container-encoding</param-name>
+         <param-value>UTF-8</param-value>
+      </init-param>
+      <init-param>
+         <param-name>encoding</param-name>
+         <param-value>UTF-8</param-value>
+      </init-param>
+      <init-param>
+         <param-name>hide-error-messages</param-name>
+         <param-value>false</param-value>
+      </init-param>
+   </servlet>
+   <!--
+        XQueryURLRewrite, servlet filter for URL rewriting and redirection.
+    -->
+   <servlet>
+      <servlet-name>XQueryURLRewrite</servlet-name>
+      <servlet-class>org.exist.http.urlrewrite.XQueryURLRewrite</servlet-class>
+      <!-- Defines the location of the controller-config.xml file,
+             which defines the root mappings. -->
+      <init-param>
+         <param-name>config</param-name>
+         <param-value>WEB-INF/controller-config.xml</param-value>
+      </init-param>
+      <!-- The controller-config.xml file could also be stored inside the db: -->
+      <!--
+        <init-param>
+			<param-name>config</param-name>
+			<param-value>xmldb:exist:///db/controller-config.xml</param-value>
+		</init-param>
+        -->
+      <!--
+        <init-param>
+			<param-name>compiled-cache</param-name>
+			<param-value>false</param-value>
+		</init-param>
+        -->
+      <!-- When true and attempting basic authentication with
+             the client, a challenge will always be sent -->
+      <init-param>
+         <param-name>send-challenge</param-name>
+         <param-value>true</param-value>
+      </init-param>
+   </servlet>
+   <!--
+        XSLTServlet applies an XSLT transformation to its input stream.
+    -->
+   <servlet>
+      <servlet-name>XSLTServlet</servlet-name>
+      <servlet-class>org.exist.http.servlets.XSLTServlet</servlet-class>
+   </servlet>
+   <!--
+        EXQuery - RESTXQ
+    -->
+   <servlet>
+      <servlet-name>RestXqServlet</servlet-name>
+      <servlet-class>org.exist.extensions.exquery.restxq.impl.RestXqServlet</servlet-class>
+   </servlet>
+   <!--
+        Webstart servlet, provides access to the java client.
+    -->
+   <servlet>
+      <servlet-name>jnlp</servlet-name>
+      <servlet-class>org.exist.webstart.JnlpServlet</servlet-class>
+   </servlet>
+   <!--
+        ====================== URL space mappings =======================
+    -->
+   <!--
+         IMPORTANT: the XQueryURLRewrite servlet filter does now serve as a single
+         entry point into the web application. All eXist-related URL  mappings are
+         handled by XQueryURLRewrite (see controller-config.xml).
+
+         The servlet mappings below are thus commented out. We keep them here
+         for documentation purposes. If you need to switch to the old setup,
+         you can re-enable the mappings below and disable them in controller-config.xml.
+
+         However, please note that some features of the website will only work if
+         XQueryURLRewrite controls the /rest servlet  (EXistServlet).
+    -->
+   <!-- XQuery URL rewriter -->
+   <servlet-mapping>
+      <servlet-name>XQueryURLRewrite</servlet-name>
+      <url-pattern>/*</url-pattern>
+   </servlet-mapping>
+   <!-- XMLRPC -->
+   <!--
+    <servlet-mapping>
+        <servlet-name>org.exist.xmlrpc.RpcServlet</servlet-name>
+        <url-pattern>/xmlrpc</url-pattern>
+    </servlet-mapping>
+    -->
+   <!-- REST -->
+   <!--
+    <servlet-mapping>
+        <servlet-name>EXistServlet</servlet-name>
+        <url-pattern>/rest/*</url-pattern>
+    </servlet-mapping>
+    -->
+   <!-- XQuery (Note: not for database stored queries) -->
+   <!--
+    <servlet-mapping>
+        <servlet-name>XQueryServlet</servlet-name>
+        <url-pattern>*.xql</url-pattern>
+    </servlet-mapping>
+    -->
+   <!--
+        ==================== various MIME type mappings ==================
+    -->
+   <mime-mapping>
+      <extension>css</extension>
+      <mime-type>text/css</mime-type>
+   </mime-mapping>
+   <mime-mapping>
+      <extension>xml</extension>
+      <mime-type>application/xml</mime-type>
+   </mime-mapping>
+   <mime-mapping>
+      <extension>xsl</extension>
+      <mime-type>application/xml+xslt</mime-type>
+   </mime-mapping>
+   <mime-mapping>
+      <extension>xconf</extension>
+      <mime-type>application/xml</mime-type>
+   </mime-mapping>
+   <mime-mapping>
+      <extension>xmap</extension>
+      <mime-type>application/xml</mime-type>
+   </mime-mapping>
+   <mime-mapping>
+      <extension>ent</extension>
+      <mime-type>text/plain</mime-type>
+   </mime-mapping>
+   <mime-mapping>
+      <extension>grm</extension>
+      <mime-type>text/plain</mime-type>
+   </mime-mapping>
+   <!--
+    <jsp-config>
+        <taglib>
+            <taglib-uri>http://exist-db.org/exist</taglib-uri>
+            <taglib-location>/WEB-INF/exist.tld</taglib-location>
+        </taglib>
+    </jsp-config>
+    -->
+   <login-config>
+      <auth-method>FORM</auth-method>
+      <realm-name>JAASLoginService</realm-name>
+      <form-login-config>
+         <form-login-page>/login/login</form-login-page>
+         <form-error-page>/login/error</form-error-page>
+      </form-login-config>
+   </login-config>
+   <!-- 
+        Enable dynamic GZip of server responses
+
+        Standard approach is to use org.eclipse.jetty.servlets.GZipFilter, the
+        javadoc describes the init-params and the conditions under which gzip encoding
+        is applied - http://download.eclipse.org/jetty/stable-7/apidocs/org/eclipse/jetty/servlets/GzipFilter.html
+
+        A more flexible approach can be gained by using org.eclipse.jetty.servlets.IncludableGzipFilter,
+        the javadoc can be found here - http://download.eclipse.org/jetty/stable-7/apidocs/org/eclipse/jetty/servlets/IncludableGzipFilter.html
+    -->
+   <!--
+    <filter>
+        <filter-name>GzipFilter</filter-name>
+
+        <filter-class>org.eclipse.jetty.servlets.IncludableGzipFilter</filter-class>
+        <!- <filter-class>org.eclipse.jetty.servlets.GzipFilter</filter-class> -!>
+
+        <!- <async-support>true</async-support> -!>
+        <init-param>
+            <param-name>bufferSize</param-name>
+            <param-value>8192</param-value>
+        </init-param>
+        <init-param>
+            <param-name>minGzipSize</param-name>
+            <param-value>2048</param-value>
+        </init-param>
+        <init-param>
+            <param-name>userAgent</param-name>
+            <param-value>(?:Mozilla[^\(]*\(compatible;\s*+([^;]*);.*)|(?:.*?([^\s]+/[^\s]+).*)</param-value>
+        </init-param>
+        <init-param>
+            <param-name>cacheSize</param-name>
+            <param-value>1024</param-value>
+        </init-param>
+        <init-param>
+            <param-name>excludedAgents</param-name>
+            <param-value>MSIE 6.0</param-value>
+        </init-param>
+    </filter>
+    <filter-mapping>
+        <filter-name>GzipFilter</filter-name>
+        <url-pattern>*</url-pattern>
+    </filter-mapping>
+    -->
+</web-app>

--- a/spec/norest/package/install.js
+++ b/spec/norest/package/install.js
@@ -1,0 +1,60 @@
+import { test } from 'tape'
+import { run, asAdmin } from '../../test.js'
+
+const testLibName = 'http://exist-db.org/apps/test-lib'
+
+async function removeTestlib (t) {
+  const { stderr } = await run('xst', ['run', `repo:undeploy("${testLibName}"),repo:remove("${testLibName}")`], asAdmin)
+  if (stderr) {
+    console.error(stderr)
+    t.fail(stderr)
+  }
+}
+
+async function cleanup (t) {
+  await removeTestlib(t)
+}
+
+test('package install without REST', async function (t) {
+  t.test('falls back to XMLRPC, succeeds', async function (st) {
+    const { stderr, stdout } = await run('xst', ['package', 'install', 'spec/fixtures/test-lib.xar'], asAdmin)
+    if (stderr) {
+      st.fail(stderr)
+      st.end()
+      return
+    }
+
+    const lines = stdout.split('\n')
+    st.equal(lines[0], 'Falling back to XMLRPC API')
+    st.equal(lines[1], 'Install test-lib.xar on https://localhost:8443')
+    st.equal(lines[2], '✔︎ uploaded')
+    st.equal(lines[3], '✔︎ installed')
+    st.end()
+  })
+
+  t.test('succeeds when enforcing upload over XMLRPC', async function (st) {
+    const { stderr, stdout } = await run('xst', ['package', 'install', '--rpc', 'spec/fixtures/test-lib.xar'], asAdmin)
+    if (stderr) {
+      st.fail(stderr)
+      st.end()
+      return
+    }
+
+    const lines = stdout.split('\n')
+    st.equal(lines[0], 'Install test-lib.xar on https://localhost:8443')
+    st.equal(lines[1], '✔︎ uploaded')
+    st.equal(lines[2], '✔︎ updated')
+    st.end()
+  })
+
+  t.test('fails with enforced upload over REST', async function (st) {
+    const { stderr, stdout } = await run('xst', ['package', 'install', '--rest', 'spec/fixtures/test-lib.xar'], asAdmin)
+
+    st.equal(stdout, 'Install test-lib.xar on https://localhost:8443\n')
+
+    st.equal(stderr, 'Response code 403 (Forbidden)\n')
+    st.end()
+  })
+
+  t.teardown(cleanup)
+})

--- a/spec/tests/list.js
+++ b/spec/tests/list.js
@@ -7,7 +7,7 @@ const testSourceFolder = 'spec'
 
 async function prepare (t) {
   try {
-    const phase1 = await run('xst', ['up', '-D', '-e', 'tests', testSourceFolder, testCollection], asAdmin)
+    const phase1 = await run('xst', ['up', '-D', '-e', 'tests', '-e', 'norest', testSourceFolder, testCollection], asAdmin)
     if (phase1.stderr) { throw Error(phase1.stderr) }
     const ensureTestsOlder = await run('xst', ['up', '-e', 'package,utility', testSourceFolder + '/tests', testCollection + '/tests'], asAdmin)
     if (ensureTestsOlder.stderr) { throw Error(ensureTestsOlder.stderr) }
@@ -181,7 +181,7 @@ test('with fixtures uploaded', async (t) => {
     if (stderr) { return st.fail(stderr) }
     const expectedlines = 'a.txt\na1.txt\na11.json\na20.txt\na22.xml\nb\nfixtures\nindex.html\ntest.js\ntest.xq\ntests\n'
 
-    st.equal(expectedlines, stdout, stdout)
+    st.equal(stdout, expectedlines, stdout)
     st.end()
   })
 
@@ -190,7 +190,7 @@ test('with fixtures uploaded', async (t) => {
     if (stderr) { return st.fail(stderr) }
     const expectedlines = 'tests\ntest.xq\ntest.js\nindex.html\nfixtures\nb\na22.xml\na20.txt\na11.json\na1.txt\na.txt\n'
 
-    st.equal(expectedlines, stdout, stdout)
+    st.equal(stdout, expectedlines, stdout)
     st.end()
   })
 
@@ -199,7 +199,7 @@ test('with fixtures uploaded', async (t) => {
     if (stderr) { return st.fail(stderr) }
     const expectedlines = 'b\nfixtures\ntests\nindex.html\ntest.js\na11.json\na.txt\na1.txt\na20.txt\na22.xml\ntest.xq\n'
 
-    st.equal(expectedlines, stdout, stdout)
+    st.equal(stdout, expectedlines, stdout)
     st.end()
   })
 
@@ -208,7 +208,7 @@ test('with fixtures uploaded', async (t) => {
     if (stderr) { return st.fail(stderr) }
     const expectedlines = 'a22.xml\nindex.html\ntest.js\na11.json\na.txt\na1.txt\na20.txt\nb\ntest.xq\nfixtures\ntests\n'
 
-    st.equal(expectedlines, stdout, stdout)
+    st.equal(stdout, expectedlines, stdout)
     st.end()
   })
 
@@ -217,7 +217,7 @@ test('with fixtures uploaded', async (t) => {
     if (stderr) { return t.fail(stderr) }
     const expectedlines = 'tests\nfixtures\ntest.xq\nb\na20.txt\na1.txt\na.txt\na11.json\ntest.js\nindex.html\na22.xml\n'
 
-    st.equal(expectedlines, stdout, stdout)
+    st.equal(stdout, expectedlines, stdout)
     st.end()
   })
 
@@ -227,7 +227,7 @@ test('with fixtures uploaded', async (t) => {
 
     const expectedlines = 'test.xq\nindex.html\na22.xml\na20.txt\na11.json\na1.txt\na.txt\nb\ntests\ntest.js\nfixtures\n'
 
-    st.equal(expectedlines, stdout, stdout)
+    st.equal(stdout, expectedlines, stdout)
     st.end()
   })
 
@@ -236,7 +236,7 @@ test('with fixtures uploaded', async (t) => {
     if (stderr) { return st.fail(stderr) }
     const expectedlines = 'fixtures\ntests\ntest.xq\nb\na.txt\na1.txt\na20.txt\na11.json\ntest.js\na22.xml\nindex.html\n'
 
-    st.equal(expectedlines, stdout, stdout)
+    st.equal(stdout, expectedlines, stdout)
     st.end()
   })
 
@@ -260,6 +260,7 @@ test('with fixtures uploaded', async (t) => {
 /db/list-test/fixtures/test-lib.xar
 /db/list-test/fixtures/test.xml
 /db/list-test/fixtures/test.xq
+/db/list-test/fixtures/web-no-rest.xml
 /db/list-test/index.html
 /db/list-test/test.js
 /db/list-test/test.xq
@@ -273,7 +274,7 @@ test('with fixtures uploaded', async (t) => {
 /db/list-test/tests/rm.js
 /db/list-test/tests/upload.js
 `
-    st.equal(expectedlines, stdout, stdout)
+    st.equal(stdout, expectedlines, stdout)
     st.end()
   })
 
@@ -291,6 +292,7 @@ test('with fixtures uploaded', async (t) => {
 /db/list-test/fixtures/test-lib.xar
 /db/list-test/fixtures/broken-test-app.xar
 /db/list-test/fixtures/test.xml
+/db/list-test/fixtures/web-no-rest.xml
 /db/list-test/tests
 /db/list-test/tests/cli.js
 /db/list-test/tests/info.js
@@ -310,7 +312,7 @@ test('with fixtures uploaded', async (t) => {
 /db/list-test/a22.xml
 /db/list-test/index.html
 `
-    st.equal(expectedlines, stdout, stdout)
+    st.equal(stdout, expectedlines, stdout)
     st.end()
   })
 


### PR DESCRIPTION
fixes #170

Try REST connection, fall back to XMLRPC and inform user that this happened.

```
; xst package install spec/fixtures/test-lib.xar
Falling back to XMLRPC API
Install test-lib.xar on https://localhost:8443
✔︎ uploaded
✔︎ installed
```