### PR TITLE
fix: accept invalid SSL cert warning

### DIFF
--- a/.github/workflows/test-no-rest.yml
+++ b/.github/workflows/test-no-rest.yml
@@ -7,35 +7,32 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # pull image 
-      - run: docker pull existdb/existdb:release
-      # create docker container
-      # --volume $(pwd)/empty:/exist/autodeploy:ro
+      - name: pull image 
+        run: docker pull existdb/existdb:release
       - name: create eXist-db Container
-        run: docker create --name exist --publish 8080:8080 --publish 8443:8443 existdb/existdb:release
-      # - name: Start eXist-db Container
-      #   run: docker start exist
-      # - name: Wait for eXist-db Startup
-      #   run: timeout 90 sh -c 'until nc -z $0 $1; do sleep 3; done' localhost 8080
-      # get web.xml (use prepared web.xml instead)
-      # - run: docker cp exist:exist/etc/webapp/WEB-INF/web.xml ./web.xml
-      # modify web.xml
-      # - run: cat web.xml | \
+        run: |
+          docker create --rm --name exist \
+              --publish 8080:8080 --publish 8443:8443 \
+              --volume ./empty:/exist/autodeploy:ro \
+              existdb/existdb:release
+      # - name: get web.xml from container (needs to have started before)
+      #   run: docker cp exist:exist/etc/webapp/WEB-INF/web.xml ./web.xml
+      # - name: modify web.xml
+      #   run: cat web.xml | \
           # tr '\n' '\r' | \
           # sed -E 's/(<param-name>hidden<\/param-name>\r[[:space:]]+<param-value>)false(<\/param-value>)/\1true\2/' | \
           # tr '\r' '\n' > modified-web.xml
       - name: Copy modified web.xml
         run: docker cp ./spec/fixtures/web-no-rest.xml exist:exist/etc/webapp/WEB-INF/web.xml
-      - name: Restart eXist-db Container
-        # run: docker stop exist && docker wait; docker start exist
+      - name: Start eXist-db Container
         run: docker start exist
-      - name: Wait for eXist-db Startup
-        run: timeout 90 sh -c 'until nc -z $0 $1; do sleep 3; done' localhost 8080
       - name: Use Node.js 20
         uses: actions/setup-node@v3
         with:
           node-version: 20
       - run: npm ci --no-optional
       - run: npm link
+      - name: Wait for container to be healthy
+        run: timeout 60s sh -c 'until docker ps | grep exist | grep -q healthy; do echo "Not ready yet."; sleep 2; done; echo "$(docker ps | grep exist)"'
       - run: npm run test:norest
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -792,9 +792,9 @@
       }
     },
     "node_modules/@existdb/node-exist": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@existdb/node-exist/-/node-exist-5.5.0.tgz",
-      "integrity": "sha512-YkKeD8g0sPFLSplEizcNjSOGea0RTth3KTiWwkzD47ckuNeFTb0iZWLufJ/DZeGpUqlqAInymHeWmD0cBdbjAw==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@existdb/node-exist/-/node-exist-5.5.1.tgz",
+      "integrity": "sha512-tIyIcAK7OD+JLHub3mvZDH4q5Bpg7M3z7drtbE/KswRyyazFitIB6QVa7lf4/le1XQ2dSa6VuyJ8mYhxs2UMBw==",
       "dependencies": {
         "got": "^12.1.0",
         "lodash.assign": "^4.0.2",
@@ -12015,9 +12015,9 @@
       "dev": true
     },
     "@existdb/node-exist": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@existdb/node-exist/-/node-exist-5.5.0.tgz",
-      "integrity": "sha512-YkKeD8g0sPFLSplEizcNjSOGea0RTth3KTiWwkzD47ckuNeFTb0iZWLufJ/DZeGpUqlqAInymHeWmD0cBdbjAw==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@existdb/node-exist/-/node-exist-5.5.1.tgz",
+      "integrity": "sha512-tIyIcAK7OD+JLHub3mvZDH4q5Bpg7M3z7drtbE/KswRyyazFitIB6QVa7lf4/le1XQ2dSa6VuyJ8mYhxs2UMBw==",
       "requires": {
         "got": "^12.1.0",
         "lodash.assign": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "maintainers": [],
   "license": "MIT",
   "dependencies": {
-    "@existdb/node-exist": "^5.5.0",
+    "@existdb/node-exist": "^5.5.1",
     "bottleneck": "^2.19.5",
     "chalk": "^5.2.0",
     "dotenv": "^16.0.3",


### PR DESCRIPTION
update node-exist to v5.5.1

This fixes a small issue: when `rejectUnauthorized` is not explicitly set users see a warning stating that Invalid SSL certificitates would be accepted when connecting to the existdb instance while the default is true.

The GitHub Actions workflow running the custom exist-db without REST was also modified to reliably wait for the container to be healthy.