### PR TITLE
fix(upload): align output, report problems

### DIFF
--- a/commands/get.js
+++ b/commands/get.js
@@ -3,7 +3,7 @@ import { writeFileSync, statSync, existsSync, mkdirSync } from 'node:fs'
 import { connect } from '@existdb/node-exist'
 
 /**
- * @typedef { import("node-exist").NodeExist } NodeExist
+ * @typedef { import("@existdb/node-exist").NodeExist } NodeExist
  */
 
 /**
@@ -114,7 +114,7 @@ async function downloadResource (db, options, resource, directory, collection, r
 
 /**
  * download a collection from an existdb instance
- * @param {NodeExist.BoundModules} db NodeExist client
+ * @param {NodeExist} db NodeExist client
  * @param {boolean} verbose
  * @param {String} collection
  * @param {String} baseCollection
@@ -149,7 +149,7 @@ async function downloadCollection (db, options, collection, baseCollection, dire
 }
 
 /**
- * Handle errors uploading a resource or creating a collection
+ * Handle errors downloading a resource or collection
  * @param {Error} e
  * @param {String} path
  */
@@ -165,7 +165,7 @@ function handleError (e, path) {
 /**
  * query db, output to standard out
  *
- * @param {NodeExist.BoundModules} db NodeExist client
+ * @param {NodeExist} db NodeExist client
  * @param {string} path db path
  * @returns {Number}
  */
@@ -181,7 +181,7 @@ async function getPathInfo (db, path) {
 
 /**
  *
- * @param {NodeExist.BoundModules} db NodeExist client
+ * @param {NodeExist} db NodeExist client
  * @param {String} source db path
  * @param {String} target local folder
  * @param {GetOptions} options options

--- a/commands/info.js
+++ b/commands/info.js
@@ -2,7 +2,13 @@ import { connect } from '@existdb/node-exist'
 import { readXquery } from '../utility/xq.js'
 
 /**
- * @typedef { import("node-exist").NodeExist } NodeExist
+ * @typedef { import("@existdb/node-exist").NodeExist } NodeExist
+ */
+
+/**
+ * @typedef {Object} InfoOptions
+ * @prop {boolean} raw output raw JSON reponse
+ * @prop {boolean} debug output detailed error
  */
 
 /**
@@ -10,6 +16,12 @@ import { readXquery } from '../utility/xq.js'
  */
 const query = readXquery('info.xq')
 
+/**
+ * gather system information on the database instance
+ * @param {NodeExist} db database client
+ * @param {InfoOptions} options command line options
+ * @returns {0|1} exit code
+ */
 async function info (db, options) {
   const result = await db.queries.readAll(query, {})
   const raw = result.pages.toString()

--- a/commands/list.js
+++ b/commands/list.js
@@ -9,7 +9,7 @@ import { getGlobMatcher } from '../utility/glob.js'
 import { getTreeFormatter, getNextIndent } from '../utility/tree.js'
 
 /**
- * @typedef { import("node-exist").NodeExist } NodeExist
+ * @typedef { import("@existdb/node-exist").NodeExist } NodeExist
  */
 
 /**
@@ -426,7 +426,7 @@ function getListRenderer (options, renderItem, sortItemList) {
 
 /**
  * list elements in exist db and output to stdout
- * @param {import("@existdb/node-exist").NodeExist} db database client
+ * @param {NodeExist} db database client
  * @param {String} collection path to collection in db
  * @param {ListOptions} options command line options
  * @returns {void}

--- a/commands/rm.js
+++ b/commands/rm.js
@@ -2,7 +2,7 @@ import { connect } from '@existdb/node-exist'
 import { readXquery } from '../utility/xq.js'
 
 /**
- * @typedef { import("node-exist").NodeExist } NodeExist
+ * @typedef { import("@existdb/node-exist").NodeExist } NodeExist
  */
 
 /**
@@ -48,7 +48,7 @@ function normalizePath (path) {
 
 /**
  * remove collections and resources in exist db
- * @param {import("@existdb/node-exist").NodeExist} db database client
+ * @param {NodeExist} db database client
  * @param {[String]} paths path to collection in db
  * @param {RemoveOptions} options command line options
  * @returns {void}

--- a/spec/tests/list.js
+++ b/spec/tests/list.js
@@ -296,9 +296,9 @@ test('with fixtures uploaded', async (t) => {
 /db/list-test/tests
 /db/list-test/tests/cli.js
 /db/list-test/tests/info.js
-/db/list-test/tests/upload.js
 /db/list-test/tests/configuration.js
 /db/list-test/tests/exec.js
+/db/list-test/tests/upload.js
 /db/list-test/tests/rm.js
 /db/list-test/tests/get.js
 /db/list-test/tests/list.js

--- a/utility/account.js
+++ b/utility/account.js
@@ -1,0 +1,38 @@
+/**
+ * @typedef { import("@existdb/node-exist").NodeExist } NodeExist
+ */
+
+/**
+ * @typedef {Object} AccountInfo
+ * @prop {Number} uid internal user id
+ * @prop {String} name user name
+ * @prop {String[]} groups the groups this user is a mebmer of
+ * @prop {Number} umask default permissions when creating new resources and collections
+ * @prop {Object} metadata additional user account information as URI-value pairs
+ * @prop {Boolean} enabled is this user account enabled?
+ * @prop {{id:number, name:string, realmId: string}} defaultGroup this user's default group info
+ */
+
+/**
+ * get the user account information for a specific user
+ * @param {NodeExist} db client connection
+ * @param {String} userName user name
+ * @returns {Promise<AccountInfo>} user info object
+ */
+export async function getAccountInfo (db, userName) {
+  const rawUserInfo = await db.users.getUserInfo(userName)
+  const { uid, name, groups, umask, metadata } = rawUserInfo
+  return {
+    uid,
+    name,
+    groups,
+    umask,
+    metadata,
+    enabled: Boolean(rawUserInfo.enabled),
+    defaultGroup: {
+      id: rawUserInfo['default-group-id'],
+      name: rawUserInfo['default-group-name'],
+      realmId: rawUserInfo['default-group-realmId']
+    }
+  }
+}

--- a/utility/connection.js
+++ b/utility/connection.js
@@ -10,6 +10,14 @@
  *     must be set for EXISTDB_USER to take effect
  */
 import { readOptionsFromEnv } from '@existdb/node-exist'
+import { getAccountInfo } from '../utility/account.js'
+
+/**
+ * @typedef { import("@existdb/node-exist").NodeExist } NodeExist
+ */
+/**
+ * @typedef { import("./account.js").AccountInfo } AccountInfo
+ */
 
 export function readConnection (argv) {
   if (argv.connectionOptions) {
@@ -18,4 +26,33 @@ export function readConnection (argv) {
   const connectionOptions = readOptionsFromEnv()
   argv.connectionOptions = connectionOptions
   return argv
+}
+
+/**
+ * get server Address
+ * @param {NodeExist} db client
+ * @returns {String} server address
+ */
+export function getServerUrl (db) {
+  const { isSecure, options } = db.client
+
+  const protocol = isSecure ? 'https:' : 'http:'
+  const isStdPort =
+    (isSecure && options.port === 443) ||
+    (!isSecure && options.port === 80)
+
+  if (isStdPort) {
+    return `${protocol}//${options.host}`
+  }
+  return `${protocol}//${options.host}:${options.port}`
+}
+
+/**
+ * get the user account information that will be used to connect to the db
+ * @param {NodeExist} db client
+ * @returns {Promise<AccountInfo>} user info object
+ */
+export async function getUserInfo (db) {
+  const { user } = db.client.options.basic_auth
+  return await getAccountInfo(db, user)
 }

--- a/utility/errors.js
+++ b/utility/errors.js
@@ -1,19 +1,66 @@
 const NETWORK_ERRORS = [
   'EPROTO',
   'ECONNREFUSED',
-  'ECONNRESET'
+  'ECONNRESET',
+  'ENOTFOUND',
+  'ETIMEDOUT',
+  'ECONNABORTED',
+  'EHOSTUNREACH'
 ]
 
-function isNetworkError (error) {
+export function isNetworkError (error) {
   return NETWORK_ERRORS.includes(error.code)
 }
 
-function isXMLRPCFault (error) {
+const FS_ERRORS = [
+  'ENOENT',
+  'EISDIR',
+  'ENOTDIR',
+  'EACCES',
+  'EEXIST',
+  'EPERM'
+]
+
+export function isFilesystemError (error) {
+  return FS_ERRORS.includes(error.code)
+}
+
+const XPATH_EXCEPTION = 'org.exist.xquery.XPathException: '
+
+export function isXMLRPCFault (error) {
   return Boolean(error.faultString)
 }
 
-function isYargsError (error) {
+const XMLRPC_FAULT = 'org.exist.xmlrpc.RpcConnection: '
+
+export function isYargsError (error) {
   return error.name === 'YError'
+}
+
+export function formatErrorMessage (error) {
+  if (isNetworkError(error)) {
+    return `Could not connect to DB! Reason: ${error.code}`
+  }
+  if (isXMLRPCFault(error)) {
+    const xpathExceptionStart = error.faultString.indexOf(XPATH_EXCEPTION)
+    if (xpathExceptionStart > 0) {
+      const trimmed = error.faultString.substring(xpathExceptionStart + XPATH_EXCEPTION.length)
+      return `XPathException: ${trimmed}`
+    }
+
+    const isMethodError = error.faultString.startsWith('Failed to invoke method')
+    if (isMethodError) {
+      const xmlrpcConnectionErrorStart = error.faultString.indexOf(XMLRPC_FAULT)
+      const trimmed = error.faultString.substring(xmlrpcConnectionErrorStart + XMLRPC_FAULT.length)
+      return `Error: ${trimmed}`
+    }
+
+    return `Error executing your query ${error.faultString}`
+  }
+  if (isYargsError(error)) {
+    return `Problem with a provided Argument:\n${error.message}`
+  }
+  return error.message
 }
 
 export function handleError (error) {

--- a/utility/message.js
+++ b/utility/message.js
@@ -1,0 +1,28 @@
+import chalk from 'chalk'
+
+/**
+ * @type {String} bright green checkmark
+ */
+export const check = chalk.greenBright('✔︎')
+/**
+ * @type {String} bright red heavy cross
+ */
+export const fail = chalk.redBright('✘')
+
+/**
+ * log operation success message
+ * @param {any[]} message
+ * @returns {void}
+ */
+export function logSuccess (message) {
+  console.log(`${check} ${message}`)
+}
+
+/**
+ * log operation failure message
+ * @param {any[]} message
+ * @returns {void}
+ */
+export function logFailure (message) {
+  console.error(`${fail} ${message}`)
+}


### PR DESCRIPTION
fixes #114

When a upload operation fails in part or in total a non-zero exit code
accompanied by a meaningful message will be added.
Created collections and resources are now actually counted.
With `--verbose` errors on resource and collection level are shown.
In general output of upload operations is now better aligned and also
colored if the terminal is capable of that.

Improved utitily modules:
- errors.js
  - recognize more network errors
  - recognize filesystem errors
  - recognize XMLRPC faults
  - export all error categorization helpers
  - add `formatErrorMessage`
- connection.js
  - new helper `getServerUrl` returns db server URL
  - new helper `getUserInfo` returns user connecting to DB

New utility modules:
- account.js
  - `getAccountInfo`: turns raw XMLRPC db user data into AccountInfo
- message.js
   - `logSucces`: helper to align operation success messages
   - `logFailure`: helper to align operation failure messages

Adapt and improve tests.
