### PR TITLE
chore(deps): use node-exist v5.5.2

### DIFF
--- a/commands/edit.js
+++ b/commands/edit.js
@@ -67,7 +67,7 @@ async function edit (db, resource, editor) {
       }
       const newFileContents = readFileSync(tempFile)
       const fileHandle = await db.documents.upload(newFileContents)
-      const uploadResult = await db.documents.parseLocal(fileHandle, resource, null)
+      const uploadResult = await db.documents.parseLocal(fileHandle, resource)
       if (!editor.isTerminalEditor) {
         console.log('upload: ', uploadResult)
       }
@@ -100,7 +100,7 @@ async function edit (db, resource, editor) {
         } else {
           const newFileContents = readFileSync(tempFile)
           const fileHandle = await db.documents.upload(newFileContents)
-          const uploadResult = await db.documents.parseLocal(fileHandle, resource, {})
+          const uploadResult = await db.documents.parseLocal(fileHandle, resource)
           console.log('upload: ', uploadResult)
         }
 

--- a/commands/info.js
+++ b/commands/info.js
@@ -23,7 +23,7 @@ const query = readXquery('info.xq')
  * @returns {0|1} exit code
  */
 async function info (db, options) {
-  const result = await db.queries.readAll(query, {})
+  const result = await db.queries.readAll(query)
   const raw = result.pages.toString()
   const json = JSON.parse(raw)
 

--- a/commands/package/list.js
+++ b/commands/package/list.js
@@ -494,7 +494,7 @@ function getSorter (options) {
  * @returns {Number} the exit code
  */
 async function listPackages (db, options) {
-  const result = await db.queries.readAll(query, {})
+  const result = await db.queries.readAll(query)
   const raw = result.pages.toString()
   if (options.raw) {
     return console.log(raw)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
-        "@existdb/node-exist": "^5.5.1",
+        "@existdb/node-exist": "^5.5.2",
         "bottleneck": "^2.19.5",
         "chalk": "^5.2.0",
         "dotenv": "^16.0.3",
@@ -787,9 +787,10 @@
       }
     },
     "node_modules/@existdb/node-exist": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@existdb/node-exist/-/node-exist-5.5.1.tgz",
-      "integrity": "sha512-tIyIcAK7OD+JLHub3mvZDH4q5Bpg7M3z7drtbE/KswRyyazFitIB6QVa7lf4/le1XQ2dSa6VuyJ8mYhxs2UMBw==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@existdb/node-exist/-/node-exist-5.5.2.tgz",
+      "integrity": "sha512-XFRL9poslXSXhBFW68guXIwCDsta+5WxHMePHSFgkgrwwProg97RMm78rSXFPxEK66RVKTUgj7Eu9ePH0aijbA==",
+      "license": "MIT",
       "dependencies": {
         "got": "^12.1.0",
         "lodash.assign": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "maintainers": [],
   "license": "MIT",
   "dependencies": {
-    "@existdb/node-exist": "^5.5.1",
+    "@existdb/node-exist": "^5.5.2",
     "bottleneck": "^2.19.5",
     "chalk": "^5.2.0",
     "dotenv": "^16.0.3",


### PR DESCRIPTION
With node-exist v5.5.2 they now really are some options arguments that were supposed to be optional now really are. These arguments are dropped were applicable.