### PR TITLE
feat(config): look for .env files in parent directories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "execa": "^7.0.0",
         "fast-glob": "^3.2.12",
         "fflate": "^0.8.2",
+        "find-up-simple": "^1.0.1",
         "semver": "^7.3.8",
         "yargs": "^17.6.2"
       },
@@ -3798,10 +3799,10 @@
       }
     },
     "node_modules/find-up-simple": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.0.tgz",
-      "integrity": "sha512-q7Us7kcjj2VMePAa02hDAF6d+MzsdsAWEwYyOpwUtlerRBkOEPBCRZrAV4XfcSN8fHAgaD0hP7miwoay6DCprw==",
-      "dev": true,
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
+      "integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "execa": "^7.0.0",
     "fast-glob": "^3.2.12",
     "fflate": "^0.8.2",
+    "find-up-simple": "^1.0.1",
     "semver": "^7.3.8",
     "yargs": "^17.6.2"
   },

--- a/utility/configure.js
+++ b/utility/configure.js
@@ -1,12 +1,17 @@
 import { readFileSync, existsSync } from 'node:fs'
 import * as dotenv from 'dotenv'
+import { findUpSync } from 'find-up-simple'
 
-// read connection options from .env file in current working directory
-dotenv.config()
+// read connection options from .env file in current working directory or any parent directory
+const path = findUpSync('.env')
+if (path) {
+  // console.log(path)
+  dotenv.config({ path })
+}
 
 /**
  * read config files in .env, .existdb.json or node-exist format
- * @param {String} configPath path to the configuarion file
+ * @param {String} configPath path to the configuration file
  * @returns {Object} configuration
  */
 export function configure (configPath) {


### PR DESCRIPTION
closes #240

Any invocation of `xst` will now automatically look for `.env` files further up the directory tree and use the first one that is found. Configuration files given with the `--config` option will override those settings.