### PR TITLE
ci: align node versions and step name

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -20,5 +20,5 @@ jobs:
         with:
           node-version: 'lts/*'
           cache: 'npm'
-      - run: npm ci --no-optional
+      - run: npm ci --omit=optional
       - run: npx commitlint --from=${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -12,14 +12,13 @@ jobs:
     name: Lint commit messages
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 'lts/*'
+          cache: 'npm'
       - run: npm ci --no-optional
       - run: npx commitlint --from=${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: 'lts/*'
           cache: 'npm'
-      - run: npm ci --no-optional
+      - run: npm ci --omit=optional
       - run: npm link
       - name: Wait for container to be healthy
         run: timeout 60s sh -c 'until docker ps | grep exist | grep -q healthy; do echo "Not ready yet."; sleep 2; done; echo "$(docker ps | grep exist)"'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,9 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: pull image 
-        run: docker pull existdb/existdb:release
+      - run: docker pull existdb/existdb:release
       - name: create eXist-db Container
         run: |
           docker create --rm --name exist \
@@ -16,10 +14,11 @@ jobs:
               existdb/existdb:release
       - name: Start eXist-db Container
         run: docker start exist
-      - name: Use Node.js 20
-        uses: actions/setup-node@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 'lts/*'
+          cache: 'npm'
       - run: npm ci --no-optional
       - run: npm link
       - name: Wait for container to be healthy

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -14,18 +14,15 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
-      - name: Install dependencies
-        run: npm ci --no-optional
-      - name: Release
-        run: npx semantic-release
+          node-version: 'lts/*'
+          cache: 'npm'
+      - run: npm ci --no-optional
+      - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version: 'lts/*'
           cache: 'npm'
-      - run: npm ci --no-optional
+      - run: npm ci --omit=optional
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-no-rest.yml
+++ b/.github/workflows/test-no-rest.yml
@@ -6,33 +6,23 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: pull image 
-        run: docker pull existdb/existdb:release
-      - name: create eXist-db Container
-        run: |
+      - run: docker pull existdb/existdb:release
+      - run: |
           docker create --rm --name exist \
               --publish 8080:8080 --publish 8443:8443 \
               --volume ./empty:/exist/autodeploy:ro \
               existdb/existdb:release
-      # - name: get web.xml from container (needs to have started before)
-      #   run: docker cp exist:exist/etc/webapp/WEB-INF/web.xml ./web.xml
-      # - name: modify web.xml
-      #   run: cat web.xml | \
-          # tr '\n' '\r' | \
-          # sed -E 's/(<param-name>hidden<\/param-name>\r[[:space:]]+<param-value>)false(<\/param-value>)/\1true\2/' | \
-          # tr '\r' '\n' > modified-web.xml
-      - name: Copy modified web.xml
+      - uses: actions/checkout@v4
+      - name: Modify web.xml in docker instance
         run: docker cp ./spec/fixtures/web-no-rest.xml exist:exist/etc/webapp/WEB-INF/web.xml
-      - name: Start eXist-db Container
-        run: docker start exist
-      - name: Use Node.js 20
-        uses: actions/setup-node@v4
+      - run: docker start exist
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 'lts/*'
+          cache: 'npm'
       - run: npm ci --no-optional
       - run: npm link
       - name: Wait for container to be healthy
         run: timeout 60s sh -c 'until docker ps | grep exist | grep -q healthy; do echo "Not ready yet."; sleep 2; done; echo "$(docker ps | grep exist)"'
-      - run: npm run test:norest
-
+      - name: Run "norest" testsuite
+        run: npm run test:norest

--- a/.github/workflows/test-no-rest.yml
+++ b/.github/workflows/test-no-rest.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           node-version: 'lts/*'
           cache: 'npm'
-      - run: npm ci --no-optional
+      - run: npm ci --omit=optional
       - run: npm link
       - name: Wait for container to be healthy
         run: timeout 60s sh -c 'until docker ps | grep exist | grep -q healthy; do echo "Not ready yet."; sleep 2; done; echo "$(docker ps | grep exist)"'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
           cache-dependency-path: 'xst'
-      - run: npm ci --no-optional
+      - run: npm ci --omit=optional
         working-directory: xst
       - run: npm link
         working-directory: xst

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,10 +27,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: xst
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Set up NodeJS v${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+          cache-dependency-path: 'xst'
       - run: npm ci --no-optional
         working-directory: xst
       - run: npm link


### PR DESCRIPTION
fixes #256

CI actions that need NodeJS will now use latest LTS version. The only exception is the test action with a matrix of versions. This should make it easier to upgrade development dependencies.

Additionally, the actions are now much terser as most of them do not have a name property. Let's see how that looks.