### PR TITLE
feat(package): improve package resolution from registries

### DIFF
--- a/commands/package/install/github.js
+++ b/commands/package/install/github.js
@@ -7,7 +7,7 @@ import { connect, getRestClient } from '@existdb/node-exist'
 import { isDBAdmin, getUserInfo } from '../../../utility/connection.js'
 import {
   removeTemporaryCollection,
-  getInstalledVersion,
+  getInstalledPackageMeta,
   putPackage
 } from '../../../utility/package.js'
 import { logFailure, logSuccess, logSkipped } from '../../../utility/message.js'
@@ -169,7 +169,7 @@ export async function handler (argv) {
     return assetMatcher.test(asset.name)
   }
 
-  const installedVersion = await getInstalledVersion(db, abbrev)
+  const installedVersion = (await getInstalledPackageMeta(db, abbrev)).version
 
   if (verbose) {
     console.log(`Preparing to install ${owner}/${repo} at version ${release}`)

--- a/commands/package/install/local.js
+++ b/commands/package/install/local.js
@@ -10,7 +10,7 @@ import {
   uploadMethod,
   removeTemporaryCollection,
   extractPackageMeta,
-  getInstalledVersion
+  getInstalledPackageMeta
 } from '../../../utility/package.js'
 import { logFailure, logSuccess, logSkipped } from '../../../utility/message.js'
 
@@ -33,7 +33,7 @@ async function install (db, upload, localFilePath, force, verbose) {
   try {
     const contents = readFileSync(localFilePath)
     const { version, abbrev, name } = extractPackageMeta(contents)
-    const installedVersion = await getInstalledVersion(db, name)
+    const installedVersion = (await getInstalledPackageMeta(db, name)).version
 
     const isUpdate =
       valid(version) && valid(installedVersion) && gt(version, installedVersion)

--- a/modules/get-installed-package-meta.xq
+++ b/modules/get-installed-package-meta.xq
@@ -36,10 +36,15 @@ function local:find($name-or-abbrev) as document-node()? {
 };
 
 try {
-    serialize(
-        map { "version": local:find($name-or-abbrev)//expath:package/@version/string() },
-        map { "method": "json" }
-    )
+    let $maybe-meta := local:find($name-or-abbrev)//expath:package
+    return
+        serialize(
+            map {
+                "version": $maybe-meta/@version/string(),
+                "name": $maybe-meta/@name/string()
+            },
+            map { "method": "json" }
+        )
 }
 catch * {
     serialize(

--- a/modules/install-from-repo.xq
+++ b/modules/install-from-repo.xq
@@ -3,7 +3,7 @@ xquery version "3.1";
 declare namespace expath="http://expath.org/ns/pkg";
 
 declare variable $packageName external;
-declare variable $publicRepoURL external;
+declare variable $registryFindUrl external;
 declare variable $version external;
 
 declare variable $latest := $version eq '';
@@ -29,12 +29,12 @@ try {
         if ($latest)
         then repo:install-and-deploy(
             $packageName,
-            $publicRepoURL || "/find"
+            $registryFindUrl
         )
         else repo:install-and-deploy(
             $packageName,
             $version,
-            $publicRepoURL || "/find"
+            $registryFindUrl
         )
 
     return

--- a/spec/tests/package/install/registry.js
+++ b/spec/tests/package/install/registry.js
@@ -158,7 +158,7 @@ test('Work with a local public registry', async function (t) {
       const lines = stdout.split('\n')
       st.equal(
         lines[0],
-        `✔︎ ${testAppName} > installed latest version at /db/apps/test-app`,
+        `✔︎ ${testAppName} > installed version 1.0.1 at /db/apps/test-app`,
         lines[0]
       )
       st.notOk(lines[1])
@@ -167,7 +167,7 @@ test('Work with a local public registry', async function (t) {
   )
 
   t.test(
-    'installs new packages from a local public registry by abbreviation',
+    'does not attmept to re-install the same package version from a local public registry, resolved by abbreviation',
     async function (st) {
       const { stderr, stdout } = await run(
         'xst',
@@ -181,23 +181,23 @@ test('Work with a local public registry', async function (t) {
         ],
         asAdmin
       )
-      st.notOk(stderr, 'There should have been no errors')
 
       const lines = stdout.split('\n')
       st.equal(
         lines[0],
-        '✔︎ test-app > installed latest version at /db/apps/test-app',
+        '- test-app > 1.0.1 is already installed',
         lines[0]
       )
+      st.equal(stderr, 'If you wish to force installation use --force.\n', stderr)
       st.notOk(lines[1])
       st.end()
     }
   )
 
-  t.test('installs new packages from the public registry', async function (st) {
+  t.test('installs new packages from the public registry (forced)', async function (st) {
     const { stderr, stdout } = await run(
       'xst',
-      ['package', 'install', 'registry', 'http://exist-db.org/apps/eXide'],
+      ['package', 'install', 'registry', 'http://exist-db.org/apps/eXide', '-f'],
       asAdmin
     )
     st.notOk(stderr, 'There should have been no errors')
@@ -205,7 +205,7 @@ test('Work with a local public registry', async function (t) {
     const lines = stdout.split('\n')
     st.equal(
       lines[0],
-      '✔︎ http://exist-db.org/apps/eXide > installed latest version at /db/apps/eXide',
+      '✔︎ http://exist-db.org/apps/eXide > installed version 3.5.4 at /db/apps/eXide',
       lines[0]
     )
     st.notOk(lines[1])
@@ -292,7 +292,7 @@ test('Work with a local public registry', async function (t) {
       // @todo: maybe a better error here? Explain user what actually went wrong?
       st.equal(
         stderr,
-        '✘ http://exist-db.org/apps/test-app > could not be found in the registry\n'
+        '✘ http://exist-db.org/apps/test-app > Package could not be found in the registry!\n'
       )
       st.end()
     }
@@ -319,7 +319,7 @@ test('Work with a local public registry', async function (t) {
       // @todo: maybe a better error here? Explain user what actually went wrong?
       st.equal(
         stderr,
-        '✘ http://exist-db.org/apps/test-app > could not be found in the registry\n',
+        '✘ http://exist-db.org/apps/test-app > Package could not be found in the registry!\n',
         stderr
       )
       st.end()

--- a/utility/package.js
+++ b/utility/package.js
@@ -3,7 +3,11 @@ import { unzipSync, strFromU8 } from 'fflate'
 import { getRestClient } from '@existdb/node-exist'
 import { readXquery } from './xq.js'
 
-const queryVersion = readXquery('get-package-version.xq')
+/**
+ * @typedef {import('@existdb/node-exist').NodeExist} NodeExist
+ */
+
+const queryInstalledPackageMeta = readXquery('get-installed-package-meta.xq')
 const queryInstallFromRepo = readXquery('install-from-repo.xq')
 
 export const expathPackageMeta = 'expath-pkg.xml'
@@ -38,55 +42,30 @@ export async function removeTemporaryCollection (db) {
   return await db.collections.remove(db.app.packageCollection)
 }
 
-export async function getInstalledVersion (db, nameOrAbbrev) {
-  const { pages } = await db.queries.readAll(queryVersion, {
+/**
+ * Query if a package identified by name or abbrev is installed in which
+ * version on the database instance
+ * @param {NodeExist} db The database connection
+ * @param {string} nameOrAbbrev The package name or abbrev to search for
+ * @returns {{version: string?, name: string? }} name and version if found
+ */
+export async function getInstalledPackageMeta (db, nameOrAbbrev) {
+  const { pages } = await db.queries.readAll(queryInstalledPackageMeta, {
     variables: { 'name-or-abbrev': nameOrAbbrev }
   })
   const rawResult = pages.toString()
-  return JSON.parse(rawResult).version
+  return JSON.parse(rawResult)
 }
 
-async function queryRepo (params, verbose, publicRepoURL) {
-  const url = `${publicRepoURL}/find?${new URLSearchParams(params)}`
-  try {
-    if (verbose) {
-      console.log(`Resolving ${url}`)
-    }
-    const found = await got.get(url).json()
-
-    return found.name
-  } catch (err) {
-    const statusCode = err.response.statusCode
-    if (statusCode === 404) {
-      // Package not found. Can be expected because the nameOrAbbrev is actually
-      // a name put into an abbrev. this is always the case, even for a legacy
-      // server
-      return null
-    }
-
-    if (err.code === 'ERR_BODY_PARSE_FAILURE') {
-      // We are talking to an old server that does not respond with JSON. Retry with XML
-      try {
-        if (await got.get(url).text()) {
-          // We are talking with an old server _and_ we got an OK result. The name is correct!
-          if (verbose) {
-            console.log(`Resolved ${params.name} to a legacy server`)
-          }
-          return params.name
-        }
-      } catch (_) {
-        return null
-      }
-    }
-
-    throw new Error(`Could not get release from: ${url}`)
-  }
-}
-
-export async function installFromRepo (
-  db,
-  { version, nameOrAbbrev, verbose, publicRepoURL }
-) {
+/**
+ * Query a package registry for a compatible version
+ * Has a fallback plan for legacy registries (public-repo prior to version 4.0.0)
+ * Throws in all error cases
+ * @param {NodeExist} db The database connection
+ * @param {{ nameOrAbbrev: string, version: string, verbose: boolean, registryUrl:string }} options The query options
+ * @returns {{version: string, name: string}} name and version if found (can contain more info)
+ */
+export async function findCompatibleVersion (db, { nameOrAbbrev, version, verbose, registryUrl }) {
   const processor = await db.server.version()
   // TODO: first query for abbrev and get name from there. If there is no `@name`, requery with name.
   const baseParams = {
@@ -98,33 +77,75 @@ export async function installFromRepo (
     baseParams.version = version
   }
 
-  const paramsForAbbrev = { ...baseParams, abbrev: nameOrAbbrev }
-  let name
+  const abbrevSearchUrl = queryRepo(registryUrl, { ...baseParams, abbrev: nameOrAbbrev })
   try {
-    name = await queryRepo(paramsForAbbrev, verbose, publicRepoURL)
-  } catch (e) {
-    return { success: false, result: e }
-  }
-
-  if (!name) {
     if (verbose) {
-      console.log('Falling back to name search')
+      console.error(`Resolving by abbrev: ${abbrevSearchUrl}`)
     }
+    return await got.get(abbrevSearchUrl).json()
+  } catch (err) {
+    // We are talking to an old server that does not respond with JSON. Retry with XML
+    // sadly we cannot allow queries by abbrev as we must have the name in order to safely
+    // remove any existing package
+    if (err.code === 'ERR_BODY_PARSE_FAILURE') {
+      throw new Error(`Found package by abbrev on ${registryUrl}. Because this is a legacy server you have to provide the name instead.`)
+    }
+    if (err?.response?.statusCode === 404) {
+      // Package not found. Can be expected because the nameOrAbbrev might contain either a name
+      // or an abbrev. This is always the case, even for a legacy server
+      if (verbose) {
+        console.log('Falling back to name search')
+      }
 
-    const paramsForName = { ...baseParams, name: nameOrAbbrev }
-    try {
-      name = await queryRepo(paramsForName, verbose, publicRepoURL)
-    } catch (e) {
-      return { success: false, result: e }
+      const nameSearchUrl = queryRepo(registryUrl, { ...baseParams, name: nameOrAbbrev })
+      try {
+        return await got.get(nameSearchUrl).json()
+      } catch (errAbbrev) {
+        if (errAbbrev?.response?.statusCode === 404) {
+          throw new Error('Package could not be found in the registry!')
+        }
+        if (errAbbrev.code === 'ERR_BODY_PARSE_FAILURE') {
+          try {
+            const responseText = await got.get(nameSearchUrl).text()
+            // We are talking with an old server _and_ we got an OK result. The name is correct!
+            if (responseText) {
+              const version = responseText.match(/version="([^"]+)"/)[1]
+              if (verbose) {
+                // console.error(await got.get(url).text())
+                console.error(`Found package ${nameOrAbbrev} on a legacy server in version ${version}`)
+              }
+              return { name: nameOrAbbrev, version }
+            }
+          } catch (_) {
+            throw new Error(_)
+          }
+        }
+        // something rather unexpected happened
+        throw new Error(errAbbrev.message)
+      }
     }
+    // something rather unexpected happened
+    throw new Error(err.message)
   }
+}
 
-  if (!name) {
-    return { success: false, result: 'could not be found in the registry' }
+function queryRepo (registryUrl, params) {
+  if (params) {
+    return `${registryUrl}/find?${new URLSearchParams(params)}`
+  }
+  return `${registryUrl}/find`
+}
+
+export async function installFromRepo (
+  db,
+  { version, packageName, verbose, registryUrl }
+) {
+  if (!packageName) {
+    return { success: false, result: 'package name missing' }
   }
 
   const { pages } = await db.queries.readAll(queryInstallFromRepo, {
-    variables: { version, packageName: name, verbose, publicRepoURL }
+    variables: { version, packageName, verbose, registryFindUrl: queryRepo(registryUrl) }
   })
   const rawResult = pages.toString()
   return JSON.parse(rawResult)


### PR DESCRIPTION
- query latest, compatible version from legacy servers, too
- always query installed version
- skip installation of the same version works now with "latest" option
- improve verbose output
- improve error handling (show unexpted errors)
- refactor for maintainability and consistent naming
  - start replacing "public repo" with "registry" internally