### PR TITLE
Limit number of parallel requests when downloading collections

### DIFF
--- a/commands/get.js
+++ b/commands/get.js
@@ -206,20 +206,14 @@ async function downloadCollectionOrResource (db, source, target, options) {
   const root = resolve(target)
 
   if (options.verbose) {
-    console.log('Downloading:', source, 'to', root)
-    console.log(
-      'Server:',
-      (db.client.isSecure ? 'https' : 'http') + '://' + db.client.options.host + ':' + db.client.options.port,
-      '(v' + options.version + ')'
-    )
-    console.log('User:', db.client.options.basic_auth.user)
+    console.error('Downloading:', source, 'to', root)
     if (options.include.length > 1 || options.include[0] !== '**') {
-      console.log('Include:\n', ...options.include, '\n')
+      console.error('Include:\n', ...options.include, '\n')
     }
     if (options.exclude.length) {
-      console.log('Exclude:\n', ...options.exclude, '\n')
+      console.error('Exclude:\n', ...options.exclude, '\n')
     }
-    console.log(`Downloading up to ${options.threads} resources at a time`)
+    console.error(`Downloading up to ${options.threads} resources at a time`)
   }
 
   // initial file


### PR DESCRIPTION
Downloading large collections caused an unpredictable amount of requests to run in parallel. The new limit makes download requests not to run in parallel.

Also use Promise.all / correct awaits for promises in general.

Reused the current tests to cover the new code.

closes #236