### PR TITLE
fix(ls): improve display of unhandled mime-types

### DIFF
--- a/commands/list.js
+++ b/commands/list.js
@@ -127,8 +127,13 @@ function formatNameColored (item, display) {
       case 'text/plain':
       case 'text/markdown':
       case null: return chalk.white.dim(display)
-      default: return chalk.white(display) + chalk.white.dim(' (' + mimetype + ')')
-      // default: return chalk.white(mimetype + display)
+      default:
+        return (
+          (mimetype.endsWith('+xml') || mimetype.endsWith('+json'))
+            ? chalk.greenBright(display)
+            : chalk.white(display)
+        ) +
+        chalk.white.dim(' (' + mimetype + ')')
     }
   }
   return chalk.blueBright(display)


### PR DESCRIPTION
Display of a file with a mime-type not handled by xst

before _and_ after


<img width="732" height="211" alt="Screenshot 2025-08-18 at 11 10 42" src="https://github.com/user-attachments/assets/de614a39-6fc0-4c1e-a4f9-8312220c02a7" />
