### PR TITLE
fix(package/uninstall): surface silent repo:remove failures in xst's output

### DIFF
--- a/commands/package/uninstall.js
+++ b/commands/package/uninstall.js
@@ -17,7 +17,22 @@ async function uninstall (nameOrAbbrev, db, options) {
   if (result.error && !result.error.code.startsWith('local:')) {
     throw new Error(result.error.description)
   }
-  const success = Boolean(result.error)
+  // success = no local error from the XQuery wrapper AND the underlying
+  // repo:remove call actually returned true. The previous version of this
+  // line was `const success = Boolean(result.error)`, which (a) reads
+  // inverted relative to its name (the value is true when error exists)
+  // and (b) didn't consider result.remove at all -- so when repo:remove
+  // silently returned false (the eXist-side behavior where
+  // RemoveFunction.eval swallows the underlying PackageException and
+  // returns boolean false), xst still printed "✔︎ uninstalled" while the
+  // package remained installed. Both arms now have to be true for the
+  // operation to count as a success, and the display logic below uses
+  // this to pick the success vs error indicator. (Note: the handler's
+  // aggregated return value at line 75 is not currently propagated to
+  // the process exit code -- yargs's `parser.parse()` in cli.js doesn't
+  // wire it up -- so this change is about the display, not exit code.
+  // Exit-code propagation is out of scope for this PR.)
+  const success = !result.error && result.remove === true
   if (raw) {
     console.log(rawResult)
     return success
@@ -26,6 +41,14 @@ async function uninstall (nameOrAbbrev, db, options) {
     const errorIndicator = chalk.red('✘')
     const extra = result.error.value ? `: ${result.error.value.join(', ')}` : ''
     console.error(`${errorIndicator} ${result.error.description}${extra}`)
+    return success
+  }
+  if (!success) {
+    // repo:remove returned false. The underlying eXist exception was
+    // swallowed by RemoveFunction.eval (eXist <= 7.0.0-beta3). Surface as
+    // best we can.
+    const errorIndicator = chalk.red('✘')
+    console.error(`${errorIndicator} ${result.name}: repo:remove returned false (no diagnostic available — check the eXist server log for the underlying exception)`)
     return success
   }
   const successIndicator = chalk.green('✔︎')


### PR DESCRIPTION
[This PR was co-authored with Claude Code. -Joe]

## Summary

`uninstall.js` displayed the green ✔︎ success indicator even when the underlying `repo:remove` XQuery call returned `false` silently. That failure mode occurs on current eXist releases because `RemoveFunction.eval` swallows all `PackageException` and returns `xs:boolean false` ([companion eXist PR](https://github.com/eXist-db/exist/pull/6432)). Net user experience today: a user runs `xst package uninstall foo`, sees `✔︎ http://.../foo uninstalled`, but the package is still installed.

## Root cause

`uninstall.js:20` set `const success = Boolean(result.error)`. `result.error` is only populated when the wrapper XQuery (`modules/uninstall.xq`) catches a local error (`local:NOT_FOUND` / `local:DEPENDENTS_FOUND`). On the path where the try-block completes and the JSON output is `{"undeploy": true, "remove": false, "name": ...}`, xst's display branch picked the success indicator because `result.error` was undefined — without consulting the actual `result.remove` value.

## Fix

- `success = !result.error && result.remove === true` — both arms must be true.
- New display branch when `result.remove === false`: print a red ✘ with a note pointing the user at the eXist server log for the underlying exception (since current-release eXist doesn't surface it to the JSON wrapper).

## Scope note

The handler's aggregated return value at the bottom of `handler()` (`return (results.filter(r => !r).length ? 1 : 0)`) is currently dead code — `cli.js`'s `await parser.parse()` doesn't propagate it to `process.exit`. Wiring exit codes through is a larger change that affects more than uninstall and is out of scope for this PR. This PR addresses the display-correctness bug only.

## Test plan

- [x] `npx tape 'spec/tests/package/uninstall.js'` — 15/15 pass against `existdb/existdb:7.0.0-beta3` Docker.
- [ ] CI

Local run command (for reproducers):

```bash
docker run -d --name xst-test-exist -p 8443:8443 existdb/existdb:7.0.0-beta3
NODE_TLS_REJECT_UNAUTHORIZED=0 NODE_NO_WARNINGS=1 npx tape 'spec/tests/package/uninstall.js'
```

## Related

- Companion eXist PR fixing the underlying silent-false in `RemoveFunction`: [eXist-db/exist#6432](https://github.com/eXist-db/exist/pull/6432). Once that ships, the `result.remove === false` branch in this PR becomes mostly defensive (against older eXist servers) since the XQuery wrapper will catch the rethrown exception and surface it via `result.error` instead.
