### PR TITLE
test: run the suite against isolated eXist instances + add a Docker harness

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -51,6 +51,7 @@ function showLogo () {
 }
 
 const parser = yargs(hideBin(process.argv))
+  .scriptName('xst')
   .config('config', 'Read configuration file', configure)
   .middleware(readConnection)
   .usageConfiguration({ 'hide-types': true })

--- a/harness/README.md
+++ b/harness/README.md
@@ -1,0 +1,93 @@
+# Test harness
+
+Docker-based helper for running the xst test suite against a real eXist-db
+instance — without a global install and without port collisions. It starts a
+throwaway container, wires the suite to it via `XST_TEST_SERVER`, and tears it
+down again.
+
+Use it so your local runs match CI instead of depending on whatever instance
+happens to be on `localhost:8443`.
+
+## Prerequisites
+
+Docker with Compose v2 (`docker compose`).
+
+## Everyday use
+
+From the repository root:
+
+```sh
+harness/xst-harness.sh up      # start existdb/existdb:release
+harness/xst-harness.sh test    # npm test against that instance
+harness/xst-harness.sh down    # stop and remove it
+```
+
+Run against another eXist version (host ports are picked automatically):
+
+```sh
+harness/xst-harness.sh up   -v 6.4.1
+harness/xst-harness.sh test -v 6.4.1
+```
+
+Hack interactively against the running instance:
+
+```sh
+eval "$(harness/xst-harness.sh env)"   # exports XST_TEST_SERVER / XST_TEST_HTTP_SERVER
+node cli.js ls /db
+```
+
+## No-REST suite
+
+`npm run test:norest` needs an instance with the REST API disabled. The harness
+can start one (web.xml is replaced with `spec/fixtures/web-no-rest.xml`, mirroring
+the [Test - No REST](../.github/workflows/test-no-rest.yml) workflow):
+
+```sh
+harness/xst-harness.sh up --norest
+harness/xst-harness.sh norest
+```
+
+## Matrix runs
+
+```sh
+harness/xst-harness.sh matrix                     # 6.4.1 5.4.1 4.10.0 × node 20 22 24
+harness/xst-harness.sh matrix -v "6.4.1" -n "24"
+```
+
+Node switching uses fnm, mise, or nvm — whichever is found; otherwise the current
+node with a warning. Per-run logs land in `/tmp/xst-matrix-<exist>-<node>.log`.
+
+## Multiple instances / git worktrees
+
+Each instance is keyed by an `ID`. Passing an explicit ID (or running from a
+`.worktrees/<n>` directory, where the ID is detected automatically) gives that
+instance its own deterministic ports, so several can run side by side:
+
+```sh
+harness/xst-harness.sh up 7        # http 10007, https 11007
+harness/xst-harness.sh up 8        # http 10008, https 11008
+harness/xst-harness.sh down --all  # stop every harness instance
+```
+
+Port scheme: numeric ID `<n>` → http `10000+n`, https `11000+n`. The default ID
+`main` uses 8080/8443 so the full suite (including `spec/tests/configuration.js`,
+which pins those ports) runs unrestricted.
+
+## Known limitations
+
+- `spec/tests/configuration.js` skips itself under `XST_TEST_SERVER` (it tests
+  connection defaults and fixtures that pin ports 8443/8080). It still runs
+  under the default `main` ID and in CI.
+- The package registry suite needs `public-repo` installed in the instance
+  (CI installs it on eXist ≥ 6). Without it that suite skips itself. To mirror CI:
+
+  ```sh
+  eval "$(harness/xst-harness.sh env)"
+  EXISTDB_SERVER=$XST_TEST_HTTP_SERVER EXISTDB_USER=admin EXISTDB_PASS= \
+    node cli.js package install github-release public-repo v4.0.0 --verbose
+  ```
+
+- If TLS verification errors appear over https, prepend
+  `NODE_TLS_REJECT_UNAUTHORIZED=0` (the container uses a self-signed cert).
+- The `release` tag can point at a pre-release that fails the package-fixture
+  install. If you hit that, pin a stable version with `-v 6.4.1`.

--- a/harness/README.md
+++ b/harness/README.md
@@ -59,9 +59,11 @@ node with a warning. Per-run logs land in `/tmp/xst-matrix-<exist>-<node>.log`.
 
 ## Multiple instances / git worktrees
 
-Each instance is keyed by an `ID`. Passing an explicit ID (or running from a
-`.worktrees/<n>` directory, where the ID is detected automatically) gives that
-instance its own deterministic ports, so several can run side by side:
+Each instance is keyed by an `ID`. In a git worktree the ID is detected
+automatically from the worktree's directory name — whatever layout you keep them
+in, siblings or `.worktrees/<n>` — and an ordinary checkout is `main`. Passing an
+explicit ID works too. Each ID gets its own deterministic ports, so several can
+run side by side:
 
 ```sh
 harness/xst-harness.sh up 7        # http 10007, https 11007

--- a/harness/compose.yaml
+++ b/harness/compose.yaml
@@ -1,0 +1,28 @@
+# Local test harness — isolated eXist-db instances for xst development.
+# Managed by harness/xst-harness.sh, or directly:
+#
+#   COMPOSE_PROJECT_NAME=xst-291 EXIST_VERSION=6.4.1 HTTP_PORT=10291 HTTPS_PORT=11291 \
+#     docker compose -f harness/compose.yaml up -d --wait
+#
+# Port 0 = let docker pick a free host port (resolve with `docker compose port`).
+services:
+  exist:
+    image: existdb/existdb:${EXIST_VERSION:-release}
+    ports:
+      - "${HTTP_PORT:-0}:8080"
+      - "${HTTPS_PORT:-0}:8443"
+
+  # REST-disabled instance for the norest suite (npm run test:norest).
+  # Start with: docker compose --profile norest ...
+  # Mirrors .github/workflows/test-no-rest.yml: web.xml is replaced before
+  # first start; autodeploy is masked with an empty tmpfs for faster boot.
+  exist-norest:
+    profiles: [norest]
+    image: existdb/existdb:${EXIST_VERSION:-release}
+    volumes:
+      - ../spec/fixtures/web-no-rest.xml:/exist/etc/webapp/WEB-INF/web.xml:ro
+    tmpfs:
+      - /exist/autodeploy
+    ports:
+      - "${NOREST_HTTP_PORT:-0}:8080"
+      - "${NOREST_HTTPS_PORT:-0}:8443"

--- a/harness/xst-harness.sh
+++ b/harness/xst-harness.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Test harness for the xst suite: isolated eXist-db instances via Docker.
+#
+#   xst-harness.sh up     [ID] [-v VERSION] [--norest]   start instance(s)
+#   xst-harness.sh env    [ID] [-v VERSION]              print eval-able exports
+#   xst-harness.sh test   [ID] [-v VERSION]              npm test against the instance
+#   xst-harness.sh norest [ID] [-v VERSION]              npm run test:norest
+#   xst-harness.sh down   [ID] [-v VERSION] | --all      stop instance(s)
+#   xst-harness.sh matrix [-v "6.4.1 5.4.1 4.10.0"] [-n "20 22 24"]
+#
+# ID defaults to the current worktree (digits of .worktrees/<n>) or "main".
+# Numeric IDs get deterministic ports: http 10000+ID, https 11000+ID.
+# "main" uses the default ports 8080/8443 so the full suite (incl.
+# spec/tests/configuration.js) runs there. Everything else is ephemeral.
+set -euo pipefail
+
+HARNESS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE="docker compose -f $HARNESS_DIR/compose.yaml"
+
+detect_id () {
+  case "$PWD" in
+    */.worktrees/*) basename "$(echo "$PWD" | sed -E 's|(.*/\.worktrees/[^/]+).*|\1|')" ;;
+    *) echo main ;;
+  esac
+}
+
+sanitize () { echo "$1" | tr '.' '-' | tr '[:upper:]' '[:lower:]'; }
+
+project () { # $1=id $2=version
+  echo "xst-$(sanitize "$1")-$(sanitize "$2")"
+}
+
+ports_for () { # $1=id → sets HTTP_PORT HTTPS_PORT (0 = ephemeral)
+  if [ "$1" = main ]; then HTTP_PORT=8080; HTTPS_PORT=8443
+  elif echo "$1" | grep -qE '^[0-9]+$'; then HTTP_PORT=$((10000 + $1)); HTTPS_PORT=$((11000 + $1))
+  else HTTP_PORT=0; HTTPS_PORT=0
+  fi
+}
+
+resolve_port () { # $1=project $2=service $3=container-port
+  $COMPOSE -p "$1" port "$2" "$3" | sed 's/.*://'
+}
+
+cmd_up () { # id version norest?
+  ports_for "$1"
+  local p; p="$(project "$1" "$2")"
+  local profiles=""
+  [ "${3:-}" = "--norest" ] && profiles="--profile norest"
+  EXIST_VERSION="$2" HTTP_PORT=$HTTP_PORT HTTPS_PORT=$HTTPS_PORT \
+    $COMPOSE -p "$p" $profiles up -d --wait
+  echo "# $p ready:" >&2
+  cmd_env "$1" "$2"
+}
+
+cmd_env () { # id version → print exports
+  local p; p="$(project "$1" "$2")"
+  local https http
+  https="$(resolve_port "$p" exist 8443)"
+  http="$(resolve_port "$p" exist 8080)"
+  if [ "$1" = main ] && [ "$https" = "8443" ]; then
+    echo "# main uses default ports; no overrides needed"
+  else
+    echo "export XST_TEST_SERVER=https://localhost:$https"
+    echo "export XST_TEST_HTTP_SERVER=http://localhost:$http"
+  fi
+  local norest_https
+  if norest_https="$(resolve_port "$p" exist-norest 8443 2>/dev/null)" && [ -n "$norest_https" ]; then
+    echo "export XST_TEST_NOREST_SERVER=https://localhost:$norest_https"
+  fi
+}
+
+ensure_deps () { [ -d node_modules ] || npm ci --omit=optional; }
+
+cmd_test () { # id version
+  ensure_deps
+  eval "$(cmd_env "$1" "$2" | grep '^export' || true)"
+  npm test
+}
+
+cmd_norest () { # id version — norest suite targets the REST-disabled instance
+  ensure_deps
+  local p; p="$(project "$1" "$2")"
+  local https; https="$(resolve_port "$p" exist-norest 8443)"
+  XST_TEST_SERVER="https://localhost:$https" npm run test:norest
+}
+
+cmd_down () { # id version | --all
+  if [ "$1" = "--all" ]; then
+    docker compose ls -q | grep '^xst-' | while read -r p; do
+      $COMPOSE -p "$p" down -v
+    done
+  else
+    $COMPOSE -p "$(project "$1" "$2")" down -v
+  fi
+}
+
+with_node () { # $1=version, rest=command — best-effort node version switching
+  local v="$1"; shift
+  if command -v fnm >/dev/null 2>&1; then fnm exec --using="$v" "$@"
+  elif command -v mise >/dev/null 2>&1; then mise exec "node@$v" -- "$@"
+  elif [ -s "$HOME/.nvm/nvm.sh" ]; then bash -c ". '$HOME/.nvm/nvm.sh' && nvm exec $v $*"
+  else
+    echo "! no node version manager found (fnm/mise/nvm) — using $(node --version)" >&2
+    "$@"
+  fi
+}
+
+cmd_matrix () { # $1=exist versions $2=node versions
+  ensure_deps
+  local results=""
+  for ev in $1; do
+    local p; p="$(project matrix "$ev")"
+    EXIST_VERSION="$ev" HTTP_PORT=0 HTTPS_PORT=0 $COMPOSE -p "$p" up -d --wait
+    local https http
+    https="$(resolve_port "$p" exist 8443)"
+    http="$(resolve_port "$p" exist 8080)"
+    for nv in $2; do
+      echo "=== eXist $ev × Node $nv (https:$https) ===" >&2
+      if XST_TEST_SERVER="https://localhost:$https" \
+         XST_TEST_HTTP_SERVER="http://localhost:$http" \
+         with_node "$nv" npm test >/tmp/xst-matrix-$ev-$nv.log 2>&1
+      then results="$results\nexist $ev × node $nv: PASS"
+      else results="$results\nexist $ev × node $nv: FAIL (/tmp/xst-matrix-$ev-$nv.log)"
+      fi
+    done
+    $COMPOSE -p "$p" down -v
+  done
+  printf '%b\n' "$results"
+}
+
+# --- argument parsing --------------------------------------------------------
+CMD="${1:-}"; shift || true
+ID="" VERSION="release" NOREST="" EXIST_VERSIONS="6.4.1 5.4.1 4.10.0" NODE_VERSIONS="20 22 24"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -v) VERSION="$2"; EXIST_VERSIONS="$2"; shift 2 ;;
+    -n) NODE_VERSIONS="$2"; shift 2 ;;
+    --norest) NOREST="--norest"; shift ;;
+    --all) ID="--all"; shift ;;
+    *) ID="$1"; shift ;;
+  esac
+done
+[ -z "$ID" ] && ID="$(detect_id)"
+
+case "$CMD" in
+  up)     cmd_up "$ID" "$VERSION" $NOREST ;;
+  env)    cmd_env "$ID" "$VERSION" ;;
+  test)   cmd_test "$ID" "$VERSION" ;;
+  norest) cmd_norest "$ID" "$VERSION" ;;
+  down)   if [ "$ID" = "--all" ]; then cmd_down --all; else cmd_down "$ID" "$VERSION"; fi ;;
+  matrix) cmd_matrix "$EXIST_VERSIONS" "$NODE_VERSIONS" ;;
+  *) sed -n '2,15p' "$0"; exit 1 ;;
+esac

--- a/harness/xst-harness.sh
+++ b/harness/xst-harness.sh
@@ -8,8 +8,8 @@
 #   xst-harness.sh down   [ID] [-v VERSION] | --all      stop instance(s)
 #   xst-harness.sh matrix [-v "6.4.1 5.4.1 4.10.0"] [-n "20 22 24"]
 #
-# ID defaults to the current worktree (digits of .worktrees/<n>) or "main".
-# Numeric IDs get deterministic ports: http 10000+ID, https 11000+ID.
+# ID defaults to the name of the current git worktree, or "main" in an ordinary
+# checkout. Numeric IDs get deterministic ports: http 10000+ID, https 11000+ID.
 # "main" uses the default ports 8080/8443 so the full suite (incl.
 # spec/tests/configuration.js) runs there. Everything else is ephemeral.
 set -euo pipefail
@@ -17,11 +17,16 @@ set -euo pipefail
 HARNESS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMPOSE="docker compose -f $HARNESS_DIR/compose.yaml"
 
+# In a linked worktree, git-dir points into <main>/.git/worktrees/<name> while
+# git-common-dir stays <main>/.git; they are identical in the main working tree.
+# That distinction — rather than the path shape — is what identifies a worktree,
+# so any layout works: siblings, .worktrees/<n>, or somewhere else entirely.
 detect_id () {
-  case "$PWD" in
-    */.worktrees/*) basename "$(echo "$PWD" | sed -E 's|(.*/\.worktrees/[^/]+).*|\1|')" ;;
-    *) echo main ;;
-  esac
+  if [ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ]; then
+    basename "$(git rev-parse --show-toplevel)"
+  else
+    echo main
+  fi
 }
 
 sanitize () { echo "$1" | tr '.' '-' | tr '[:upper:]' '[:lower:]'; }

--- a/readme.md
+++ b/readme.md
@@ -276,7 +276,25 @@ run the testsuite with
 npm test
 ```
 
-**NOTE:** You will need to have an instance of existdb running (usually a local development instance).
+**NOTE:** The test suite runs against a real eXist-db instance — either a local
+development instance you already have, or one started with the harness below.
+
+### Running a test instance
+
+The `harness/` directory has a Docker-based helper that starts an isolated
+eXist-db, points the suite at it, and cleans up afterwards — no global install,
+no port juggling, and closer to what CI does:
+
+```bash
+harness/xst-harness.sh up      # start eXist-db (existdb/existdb:release)
+harness/xst-harness.sh test    # npm test against it
+harness/xst-harness.sh down    # stop and remove it
+```
+
+It can also start a REST-disabled instance for `npm run test:norest`, run a
+version matrix, and give several isolated instances (e.g. one per git worktree)
+their own ports. See [harness/README.md](harness/README.md) for the full set of
+commands and options.
 
 ### Coverage
 
@@ -297,7 +315,8 @@ on instances where the REST API is disabled. You can run those with
 npm run test:norest
 ```
 
-**NOTE:** Keep in mind they will only run successfully against an instance that actually has REST disabled.
+**NOTE:** Keep in mind they will only run successfully against an instance that actually has REST disabled
+(`harness/xst-harness.sh up --norest` starts one).
 The [Test - No REST](.github/workflows/test-no-rest.yml) GitHub Action makes use of this.
 
 ## Contributing

--- a/spec/test.js
+++ b/spec/test.js
@@ -1,8 +1,45 @@
 import { spawn } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
 
 /**
  * @typedef {Promise<{stderr?: string, stdout?: string, code: number}>} CommandResult
  */
+
+// ---------------------------------------------------------------------------
+// Test target resolution
+//
+// The suite always tests the CLI of THIS checkout by spawning
+// `node <checkout>/cli.js` — never a globally installed or npm-linked xst.
+// This makes `npm test` safe in git worktrees: each worktree tests its own
+// code. Set XST_TEST_BIN to test a packaged binary instead (e.g. ./xst-linux).
+// ---------------------------------------------------------------------------
+const cliPath = fileURLToPath(new URL('../cli.js', import.meta.url))
+const testBin = process.env.XST_TEST_BIN
+
+function resolveXst (cmd, args = []) {
+  if (cmd !== 'xst') { return [cmd, args] }
+  if (testBin) { return [testBin, args] }
+  return [process.execPath, [cliPath, ...args]]
+}
+
+// ---------------------------------------------------------------------------
+// Test server resolution
+//
+// Defaults match CI: an eXist-db instance with its HTTPS/HTTP ports published
+// on localhost:8443/8080. To run the suite against an isolated instance (e.g.
+// per-worktree containers on other ports) set
+//
+//   XST_TEST_SERVER=https://localhost:11291 \
+//   XST_TEST_HTTP_SERVER=http://localhost:10291 npm test
+//
+// When XST_TEST_SERVER is set it is injected as EXISTDB_SERVER into every
+// spawned process; suites that specifically test connection *defaults*
+// (spec/tests/configuration.js) skip themselves in that case.
+// ---------------------------------------------------------------------------
+export const isIsolated = Boolean(process.env.XST_TEST_SERVER)
+export const testServer = process.env.XST_TEST_SERVER || 'https://localhost:8443'
+export const testHttpServer = process.env.XST_TEST_HTTP_SERVER || 'http://localhost:8080'
+const serverEnv = isIsolated ? { EXISTDB_SERVER: testServer } : {}
 
 /**
  * Run an shell command
@@ -13,10 +50,11 @@ import { spawn } from 'node:child_process'
  * @returns {CommandResult} The result of running the command
  */
 export async function run (cmd, args, options = cleanEnv) {
+  const [command, commandArgs] = resolveXst(cmd, args)
   return new Promise((resolve, reject) => {
     let stderr
     let stdout
-    const proc = spawn(cmd, args, options)
+    const proc = spawn(command, commandArgs, options)
     proc.stdout.on('data', (data) => {
       stdout ? (stdout += data.toString()) : (stdout = data.toString())
     })
@@ -45,11 +83,13 @@ export async function run (cmd, args, options = cleanEnv) {
  * @returns {CommandResult} The result of the pipe
  */
 export async function runPipe (cmd1, args1, cmd2, args2, options = cleanEnv) {
+  const [command1, commandArgs1] = resolveXst(cmd1, args1)
+  const [command2, commandArgs2] = resolveXst(cmd2, args2)
   return new Promise((resolve, reject) => {
     let stderr
     let stdout
-    const proc1 = spawn(cmd1, args1, options)
-    const proc2 = spawn(cmd2, args2, options)
+    const proc1 = spawn(command1, commandArgs1, options)
+    const proc2 = spawn(command2, commandArgs2, options)
     proc1.stdout.pipe(proc2.stdin)
 
     proc2.stdout.on('data', (data) => {
@@ -68,14 +108,14 @@ export async function runPipe (cmd1, args1, cmd2, args2, options = cleanEnv) {
 // guard test execution against environment variables in development setups
 const { EXISTDB_PASS, EXISTDB_USER, EXISTDB_SERVER, ...filteredEnv } = process.env
 export const cleanEnv = {
-  env: filteredEnv
+  env: { ...filteredEnv, ...serverEnv }
 }
 export const asGuest = {
-  env: { ...filteredEnv, EXISTDB_USER: 'guest', EXISTDB_PASS: 'guest' }
+  env: { ...filteredEnv, ...serverEnv, EXISTDB_USER: 'guest', EXISTDB_PASS: 'guest' }
 }
 export const asAdmin = {
-  env: { ...filteredEnv, EXISTDB_USER: 'admin', EXISTDB_PASS: '' }
+  env: { ...filteredEnv, ...serverEnv, EXISTDB_USER: 'admin', EXISTDB_PASS: '' }
 }
 export function forceColorLevel (level) {
-  return { env: { ...filteredEnv, FORCE_COLOR: level } }
+  return { env: { ...filteredEnv, ...serverEnv, FORCE_COLOR: level } }
 }

--- a/spec/test.js
+++ b/spec/test.js
@@ -41,6 +41,14 @@ export const testServer = process.env.XST_TEST_SERVER || 'https://localhost:8443
 export const testHttpServer = process.env.XST_TEST_HTTP_SERVER || 'http://localhost:8080'
 const serverEnv = isIsolated ? { EXISTDB_SERVER: testServer } : {}
 
+// Some suites (spec/tests/exec.js) run command handlers in-process via the
+// yargs parser instead of spawning the CLI; those read process.env directly.
+// Inject the override into this process too, so in-process tests hit the
+// same isolated instance as spawned ones.
+if (isIsolated) {
+  process.env.EXISTDB_SERVER = testServer
+}
+
 /**
  * Run an shell command
  *

--- a/spec/tests/configuration.js
+++ b/spec/tests/configuration.js
@@ -1,7 +1,13 @@
 import { test } from 'tape'
-import { run, asAdmin, cleanEnv } from '../test.js'
+import { run, asAdmin, cleanEnv, isIsolated } from '../test.js'
 
-test('no config file or env variables defaults to guest user', async function (t) {
+// This suite tests connection *defaults* and fixture config files, all of
+// which pin the default ports (8443/8080). When the suite is pointed at an
+// isolated instance via XST_TEST_SERVER these tests cannot pass and are
+// skipped — they still run in CI and in default local runs.
+const opts = { skip: isIsolated }
+
+test('no config file or env variables defaults to guest user', opts, async function (t) {
   const { stderr, stdout } = await run('xst', ['exec', '-f', 'modules/whoami.xq'])
   if (stderr) {
     return t.fail(stderr)
@@ -13,7 +19,7 @@ test('no config file or env variables defaults to guest user', async function (t
   t.end()
 })
 
-test('read config file', async function (t) {
+test('read config file', opts, async function (t) {
   const { stderr, stdout } = await run('xst', ['exec', '--config', 'spec/fixtures/.xstrc', '-f', 'modules/whoami.xq'])
   if (stderr) {
     return t.fail(stderr)
@@ -25,7 +31,7 @@ test('read config file', async function (t) {
   t.end()
 })
 
-test('reads environment variables', async function (t) {
+test('reads environment variables', opts, async function (t) {
   const { stderr, stdout } = await run('xst', ['exec', '-f', 'modules/whoami.xq'], asAdmin)
   if (stderr) {
     return t.fail(stderr)
@@ -37,7 +43,7 @@ test('reads environment variables', async function (t) {
   t.end()
 })
 
-test('reads configuration from .env', async function (t) {
+test('reads configuration from .env', opts, async function (t) {
   const { stderr, stdout } = await run('xst', ['exec', '--config', 'spec/fixtures/.env', '-f', 'modules/whoami.xq'])
   if (stderr) {
     return t.fail(stderr)
@@ -49,7 +55,7 @@ test('reads configuration from .env', async function (t) {
   t.end()
 })
 
-test('reads configuration from .env.staging', async function (t) {
+test('reads configuration from .env.staging', opts, async function (t) {
   const { stderr, stdout } = await run('xst', ['exec', '--config', 'spec/fixtures/.env.staging', '-f', 'modules/whoami.xq'])
   if (stderr) {
     return t.fail(stderr)
@@ -61,7 +67,7 @@ test('reads configuration from .env.staging', async function (t) {
   t.end()
 })
 
-test('reads connection from .existdb.json', async function (t) {
+test('reads connection from .existdb.json', opts, async function (t) {
   const { stderr, stdout } = await run('xst', ['exec', '--config', 'spec/fixtures/.existdb.json', '-f', 'modules/whoami.xq'])
   if (stderr) {
     return t.fail(stderr)
@@ -73,7 +79,7 @@ test('reads connection from .existdb.json', async function (t) {
   t.end()
 })
 
-test('connection options set in configuration overrides environment variables', async function (t) {
+test('connection options set in configuration overrides environment variables', opts, async function (t) {
   const { stderr, stdout } = await run('xst', ['exec', '--config', 'spec/fixtures/.env', '-f', 'modules/whoami.xq'], asAdmin)
   if (stderr) {
     return t.fail(stderr)
@@ -85,14 +91,14 @@ test('connection options set in configuration overrides environment variables', 
   t.end()
 })
 
-test('fail if config file was not found', async function (t) {
+test('fail if config file was not found', opts, async function (t) {
   const { stderr, stdout } = await run('xst', ['exec', '--config', 'non-existent.file', '-f', 'modules/whoami.xq'], asAdmin)
   if (stdout) return t.fail(stdout)
   t.ok(stderr, stderr)
   t.end()
 })
 
-test('configuration cascade', function (st) {
+test('configuration cascade', opts, function (st) {
   st.test('connection.xstrc fails to connect (certificate expired)', async function (t) {
     const { stderr, stdout } = await run('xst', ['exec', '--config', 'spec/fixtures/connection.xstrc', '-f', 'modules/whoami.xq', '--verbose'])
     const lines = stderr.split('\n')

--- a/spec/tests/exec.js
+++ b/spec/tests/exec.js
@@ -1,12 +1,18 @@
 import { test } from 'tape'
 import yargs from 'yargs'
 import * as exec from '../../commands/exec.js'
+import { readConnection } from '../../utility/connection.js'
 import { runPipe } from '../test.js'
 
-// a yargs instance must not be reused across parses: on a reused instance a
+// Mirror cli.js: resolve connection options from the environment so in-process
+// handlers connect to the same instance as spawned ones (the isolated server
+// under XST_TEST_SERVER, or the CI default otherwise). Without this the handler
+// falls back to node-exist's hardcoded default and, under isolation, floods an
+// uncaught ECONNREFUSED that crashes the suite.
+// A yargs instance must not be reused across parses: on a reused instance a
 // boolean option next to the positional (e.g. `execute --stats 1+1`) silently
-// drops the positional, so each parse gets a fresh parser
-const parser = () => yargs().scriptName('xst').command(exec).help().fail(false)
+// drops the positional, so each parse gets a fresh parser.
+const parser = () => yargs().scriptName('xst').command(exec).middleware(readConnection).help().fail(false)
 
 const execCmd = async (cmd, args) => {
   return await yargs()

--- a/spec/tests/get.js
+++ b/spec/tests/get.js
@@ -182,12 +182,12 @@ test('with test collection', async (t) => {
 
     // files are not downloaded in reproducible order
     st.equal(
-      lines.filter((l) => /^✔︎ created directory [/\w]+\/get-test/.exec(l)).length,
+      lines.filter((l) => /^✔︎ created directory [/.\w-]+\/get-test/.exec(l)).length,
       3,
       'notify 3 directories created'
     )
     st.equal(
-      lines.filter((l) => /^✔︎ downloaded resource [/\w]+\/get-test/.exec(l)).length,
+      lines.filter((l) => /^✔︎ downloaded resource [/.\w-]+\/get-test/.exec(l)).length,
       10,
       'notify 10 resources downloaded'
     )

--- a/spec/tests/get.js
+++ b/spec/tests/get.js
@@ -1,5 +1,5 @@
 import { test } from 'tape'
-import { run, asAdmin } from '../test.js'
+import { run, asAdmin, testServer } from '../test.js'
 import { readdirSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
@@ -172,7 +172,7 @@ test('with test collection', async (t) => {
     const { stderr, stdout } = await run('xst', ['get', '--verbose', testCollection, '.'], asAdmin)
     st.plan(9)
     const verboseLines = stderr.split('\n')
-    st.equal(verboseLines[0], 'Connecting to https://localhost:8443 as admin', verboseLines[0])
+    st.equal(verboseLines[0], `Connecting to ${testServer} as admin`, verboseLines[0])
     st.ok(verboseLines[1].startsWith('Downloading /db/get-test to'), verboseLines[1])
     st.equal(verboseLines[2], 'Downloading up to 4 resources at a time', verboseLines[2])
     st.equal(verboseLines[3], '', verboseLines[3])

--- a/spec/tests/info.js
+++ b/spec/tests/info.js
@@ -1,5 +1,5 @@
 import { test } from 'tape'
-import { run, asAdmin } from '../test.js'
+import { run, asAdmin, testServer } from '../test.js'
 
 test("calling 'xst info'", async (t) => {
   const { stderr, stdout } = await run('xst', ['info'])
@@ -16,7 +16,7 @@ test("calling 'xst info'", async (t) => {
 test("calling 'xst info --verbose'", async (t) => {
   const { stderr, stdout } = await run('xst', ['info', '--verbose'])
   t.plan(5)
-  t.equal(stderr, 'Connecting to https://localhost:8443 as guest\n', 'connection and user output on stderr')
+  t.equal(stderr, `Connecting to ${testServer} as guest\n`, 'connection and user output on stderr')
 
   const lines = stdout.split('\n')
   t.equal(lines.length, 4, 'outputs four lines')

--- a/spec/tests/package/install/registry.js
+++ b/spec/tests/package/install/registry.js
@@ -1,6 +1,8 @@
 import { readFile } from 'node:fs/promises'
 import test from 'tape'
-import { run, asAdmin } from '../../../test.js'
+import { run, asAdmin, testHttpServer } from '../../../test.js'
+
+const publicRepo = `${testHttpServer}/exist/apps/public-repo`
 
 const testAppName = 'http://exist-db.org/apps/test-app'
 const testLibName = 'http://exist-db.org/apps/test-lib'
@@ -33,8 +35,13 @@ async function cleanup (t) {
 }
 
 async function isLocalRepoAvailable () {
-  const { status } = await fetch('http://localhost:8080/exist/apps/public-repo')
-  return status === 200
+  try {
+    const { status } = await fetch(publicRepo)
+    return status === 200
+  } catch (_) {
+    // connection refused — no instance (or no public-repo) on this port
+    return false
+  }
 }
 
 /**
@@ -49,9 +56,8 @@ async function installPackageToLocalRepo (t) {
     formData.append('files[]', blob, app)
     formData.append('', '\\')
 
-    // TODO: Read in localhost
     const { status } = await fetch(
-      'http://localhost:8080/exist/apps/public-repo/publish',
+      `${publicRepo}/publish`,
       {
         method: 'post',
         headers: {
@@ -122,7 +128,7 @@ test('Work with a local public registry', async function (t) {
       'install',
       'registry',
       '--registry',
-      'http://localhost:8080/exist/apps/public-repo',
+      publicRepo,
       testAppName
     ])
     st.equal(
@@ -145,7 +151,7 @@ test('Work with a local public registry', async function (t) {
           'install',
           'registry',
           '--registry',
-          'http://localhost:8080/exist/apps/public-repo',
+          publicRepo,
           testAppName
         ],
         asAdmin
@@ -173,7 +179,7 @@ test('Work with a local public registry', async function (t) {
           'install',
           'registry',
           '--registry',
-          'http://localhost:8080/exist/apps/public-repo',
+          publicRepo,
           'test-app'
         ],
         asAdmin
@@ -222,7 +228,7 @@ test('Work with a local public registry', async function (t) {
           'install',
           'registry',
           '--registry',
-          'http://localhost:8080/exist/apps/public-repo',
+          publicRepo,
           testAppName,
           '1.0.1'
         ],
@@ -248,7 +254,7 @@ test('Work with a local public registry', async function (t) {
         'install',
         'registry',
         '--registry',
-        'http://localhost:8080/exist/apps/public-repo',
+        publicRepo,
         testAppName,
         '1.0.1',
         '--force'
@@ -279,7 +285,7 @@ test('Work with a local public registry', async function (t) {
           'install',
           'registry',
           '--registry',
-          'http://localhost:8080/exist/apps/public-repo',
+          publicRepo,
           testAppName,
           '10.98.2'
         ],
@@ -308,7 +314,7 @@ test('Work with a local public registry', async function (t) {
           'install',
           'registry',
           '--registry',
-          'http://localhost:8080/doesnotexist/',
+          `${testHttpServer}/doesnotexist/`,
           testAppName
         ],
         asAdmin
@@ -319,7 +325,7 @@ test('Work with a local public registry', async function (t) {
       // @todo: maybe a better error here? Explain user what actually went wrong?
       st.equal(
         stderr,
-        '✘ http://exist-db.org/apps/test-app > Server responded with a Servlet error. Probably a wrong path to the public-repo or public-repo not installed. Please check the URL http://localhost:8080/doesnotexist/\n',
+        `✘ http://exist-db.org/apps/test-app > Server responded with a Servlet error. Probably a wrong path to the public-repo or public-repo not installed. Please check the URL ${testHttpServer}/doesnotexist/\n`,
         stderr
       )
       st.end()

--- a/spec/tests/package/list.js
+++ b/spec/tests/package/list.js
@@ -1,5 +1,5 @@
 import { test } from 'tape'
-import { run, asAdmin } from '../../test.js'
+import { run, asAdmin, testServer } from '../../test.js'
 
 const testAppName = 'http://exist-db.org/apps/test-app'
 const testLibName = 'http://exist-db.org/apps/test-lib'
@@ -86,7 +86,7 @@ test.skip('sorts by type and installation date', async function (t) {
 
   if (stderr) { return t.fail(stderr) }
   const lines = stdout.split('\n')
-  t.equal(lines[0], 'Install test-app.xar on https://localhost:8443')
+  t.equal(lines[0], `Install test-app.xar on ${testServer}`)
 })
 
 test('with new package', async function (t) {

--- a/spec/tests/upload.js
+++ b/spec/tests/upload.js
@@ -1,5 +1,5 @@
 import { test } from 'tape'
-import { run, asAdmin } from '../test.js'
+import { run, asAdmin, testServer } from '../test.js'
 
 const testCollection = '/db/upload-test'
 
@@ -41,7 +41,7 @@ test('uploading files and folders', function (t) {
     const { stderr, stdout, code } = await run('xst', ['up', '-v', 'spec/test.js', testCollection])
     st.equal(code, 1, 'exit code 1')
     const lines = stderr.split('\n')
-    st.equal(lines[0], 'Connecting to https://localhost:8443 as guest', lines[0])
+    st.equal(lines[0], `Connecting to ${testServer} as guest`, lines[0])
     st.equal(lines[1], '✘ test.js Error: Write permission is not granted on the Collection.', lines[1])
     st.ok(/Upload of .+?spec\/test\.js failed\./.test(lines[2]), lines[2])
     st.ok(stdout, 'additional info is displayed')
@@ -72,7 +72,7 @@ test('uploading files and folders', function (t) {
     const { stderr, stdout, code } = await run('xst', ['up', '-v', 'spec/fixtures/test.xq', testCollection])
     st.equal(code, 1, 'exit code 1')
     const lines = stderr.split('\n')
-    st.equal(lines[0], 'Connecting to https://localhost:8443 as guest', lines[0])
+    st.equal(lines[0], `Connecting to ${testServer} as guest`, lines[0])
     st.equal(lines[1], '✘ test.xq Error: A resource with the same name already exists in the target collection \'/db/upload-test\', and you do not have write access on that resource.')
     st.ok(/Upload of .+?spec\/fixtures\/test\.xq failed\./.test(lines[2]))
     st.ok(stdout, 'additional info is displayed')


### PR DESCRIPTION
## What

Makes the test suite runnable against a configurable, isolated eXist-db instance instead of assuming one on `localhost:8443`, and adds a small Docker-based harness to start one. Groundwork for running the suite in parallel git worktrees and across eXist versions.

## Why

`npm test` previously required a manually-provided eXist on the default ports, and the readme said as much without explaining how to get one — fiddly for contributors and impossible to run several branches' suites side by side.

## Changes

- **Server-configurable suite** — `XST_TEST_SERVER` / `XST_TEST_HTTP_SERVER` override the target instance and are injected as `EXISTDB_SERVER` into spawned *and* in-process command handlers. `spec/tests/configuration.js` (which tests connection *defaults*) skips itself under an override; the registry suite no longer crashes when `public-repo` isn't installed.
- **Worktree-safe CLI resolution** — the suite always spawns this checkout's `cli.js` (never a globally installed / `PATH` `xst`), so `npm test` is safe in git worktrees.
- **In-process handler fix** — the exec suite drives handlers through a bare yargs parser; it now applies the `readConnection` middleware so those handlers reach the configured instance instead of throwing an uncaught `ECONNREFUSED` at the default port and aborting the run.
- **`fix:` pin the program name** — yargs derived `$0` from `argv[1]`, so running as `node cli.js` printed usage as `cli.js …`; pin `.scriptName('xst')` so help/usage are stable regardless of launch path.
- **Test adjustments** — accept dotted/hyphenated cwd paths in the get spec (e.g. `.worktrees/291`); update the list size-sort expectations after `spec/test.js` grew past eXist's XML page-size boundary (verified byte-identical on eXist 6.4.1 and 7.0.0-beta3).
- **Harness** — `harness/` (Docker Compose + a small wrapper) starts an isolated instance, wires the suite to it, and tears it down; supports a REST-disabled instance for `test:norest`, a version matrix, and per-worktree instances. Documented in the readme's Testing section and `harness/README.md`.

## Notes

- Non-isolated behaviour (no `XST_TEST_SERVER`) is unchanged, so the existing CI matrix is unaffected.
- Draft: CI is expected red until #377 lands — the `release` matrix cell fails independently of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)