### PR TITLE
ci: allow latest and release to fail for the moment

### DIFF
--- a/.github/workflows/test-no-rest.yml
+++ b/.github/workflows/test-no-rest.yml
@@ -6,12 +6,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - run: docker pull existdb/existdb:release
+      - run: docker pull existdb/existdb:6.4.1
       - run: |
           docker create --rm --name exist \
               --publish 8080:8080 --publish 8443:8443 \
               --volume ./empty:/exist/autodeploy:ro \
-              existdb/existdb:release
+              existdb/existdb:6.4.1
       - uses: actions/checkout@v7
       - name: Modify web.xml in docker instance
         run: docker cp ./spec/fixtures/web-no-rest.xml exist:exist/etc/webapp/WEB-INF/web.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,14 +9,15 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    # Exist latest is in development, so failures are allowed, but valuable to log
-    continue-on-error: ${{ matrix.exist-version == 'latest' }}
+    # Exist latest and release are in development, so failures are allowed
+    # (release currently broken upstream), but valuable to log
+    continue-on-error: ${{ matrix.exist-version == 'latest' || matrix.exist-version == 'release' }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
         node-version: [20, 22, 24]
-        exist-version: [latest, release, 5.4.1, 4.10.0]
+        exist-version: [latest, release, 6.4.1, 5.4.1, 4.10.0]
     services:
       exist:
         image: existdb/existdb:${{ matrix.exist-version }}

--- a/spec/tests/package/install/registry.js
+++ b/spec/tests/package/install/registry.js
@@ -201,9 +201,11 @@ test('Work with a local public registry', async function (t) {
     st.notOk(stderr, 'There should have been no errors')
 
     const lines = stdout.split('\n')
-    st.equal(
+    // eXide is installed from the live public registry, so its version
+    // changes over time
+    st.match(
       lines[0],
-      '✔︎ http://exist-db.org/apps/eXide > installed version 3.5.4 at /db/apps/eXide',
+      /^✔︎ http:\/\/exist-db\.org\/apps\/eXide > installed version \d+\.\d+\.\d+ at \/db\/apps\/eXide$/,
       lines[0]
     )
     st.notOk(lines[1])


### PR DESCRIPTION
While waiting for :release to finally be updated we should not be blocked by it.
Select 6.4.1 as the last version that is gating releases for now.