### PR TITLE
feat: remove resources matching glob patterns

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -51,6 +51,7 @@ function showLogo () {
 }
 
 const parser = yargs(hideBin(process.argv))
+  .scriptName('xst')
   .config('config', 'Read configuration file', configure)
   .middleware(readConnection)
   .usageConfiguration({ 'hide-types': true })

--- a/commands/rm.js
+++ b/commands/rm.js
@@ -1,8 +1,23 @@
+import chalk from 'chalk'
 import { getXmlRpcClient } from '@existdb/node-exist'
 import { readXquery } from '../utility/xq.js'
+import { stringList } from '../utility/options.js'
+import { toRegExpPattern } from '../utility/glob.js'
+import { assertAbsoluteDbPath, normalizeDbPath } from '../utility/db-path.js'
 
 /**
  * @typedef { import("@existdb/node-exist").NodeExist } NodeExist
+ */
+
+/**
+ * @typedef {Object} RemoveOptions
+ * @prop {Boolean} recursive descend down the collection tree
+ * @prop {Boolean} force remove non-empty collections
+ * @prop {Boolean} dryRun only list what would be removed
+ * @prop {Boolean} usePatterns paths are search roots, matching children are removed
+ * @prop {String[]} includePatterns regular expressions matched against child names
+ * @prop {String[]} excludePatterns regular expressions that win over includePatterns
+ * @prop {Boolean} [debug] output raw query results
  */
 
 /**
@@ -26,11 +41,6 @@ const protectedPaths = [
 function guardProtectedPaths (paths) {
   let foundProtectedPaths = false
   paths.forEach(path => {
-    if (path === '') {
-      console.error('Cannot remove protected path: /')
-      foundProtectedPaths = true
-      return
-    }
     if (protectedPaths.includes(path)) {
       console.error(`Cannot remove protected path: ${path}`)
       foundProtectedPaths = true
@@ -39,32 +49,27 @@ function guardProtectedPaths (paths) {
   return foundProtectedPaths
 }
 
-function normalizePath (path) {
-  if (path.endsWith('/')) {
-    return path.substring(0, path.length - 1)
-  }
-  return path
-}
-
 /**
  * remove collections and resources in exist db
  * @param {NodeExist} db database client
- * @param {[String]} paths path to collection in db
+ * @param {String[]} paths paths to collections and resources in db
  * @param {RemoveOptions} options command line options
  * @returns {void}
  */
 async function rm (db, paths, options) {
-  const { /* glob, dryRun, */ recursive, force } = options
+  const { recursive, force, dryRun, usePatterns, includePatterns, excludePatterns } = options
   const result = await db.queries.readAll(query, {
     variables: {
       paths,
-      // glob,
-      // dryRun,
+      'include-patterns': includePatterns,
+      'exclude-patterns': excludePatterns,
+      'dry-run': dryRun,
+      'protected-paths': protectedPaths,
       recursive,
       force
     }
   })
-  const json = await JSON.parse(result.pages.toString())
+  const json = JSON.parse(result.pages.toString())
   if (json.error) {
     if (options.debug) {
       console.error(json.error)
@@ -75,10 +80,19 @@ async function rm (db, paths, options) {
     console.log(json)
   }
 
+  if (usePatterns && json.list.length === 0) {
+    console.error(chalk.yellow('Nothing matched'))
+    process.exit(9)
+  }
+
   json.list.forEach(item => {
-    const { success, path } = item
+    const { success, path, skipped, reason } = item
+    if (skipped) {
+      console.log('- ' + path + ' - ' + reason)
+      return
+    }
     if (success) {
-      console.log('✔︎ ' + path)
+      console.log((json.dryRun ? 'would remove: ' : '✔︎ ') + path)
       return
     }
     console.error('✘ ' + path + ' - ' + item.error.description)
@@ -89,18 +103,24 @@ export const command = ['remove [options] <paths..>', 'rm', 'delete', 'del']
 export const describe = 'Remove collections or resources'
 
 const options = {
-  // g: {
-  //   alias: 'glob',
-  //   describe:
-  //         'remove only collection names and resources whose name match the pattern.',
-  //   type: 'string',
-  //   default: '*'
-  // },
-  // d: {
-  //   alias: 'dry-run',
-  //   describe: 'Only list what would be deleted',
-  //   type: 'boolean'
-  // },
+  i: {
+    alias: 'include',
+    describe:
+      'Remove only children of the given collections whose name matches one or more of the patterns (comma separated). Without patterns, paths are removed as given.',
+    ...stringList
+  },
+  e: {
+    alias: 'exclude',
+    describe:
+      'Keep children whose name matches one or more of the patterns (comma separated). Excludes win over includes.',
+    ...stringList
+  },
+  d: {
+    alias: 'dry-run',
+    describe: 'Only list what would be removed',
+    type: 'boolean',
+    default: false
+  },
   r: {
     alias: 'recursive',
     describe: 'Descend down the collection tree',
@@ -115,7 +135,7 @@ const options = {
   }
 }
 
-export const builder = yargs => yargs.options(options)
+export const builder = yargs => yargs.options(options).nargs({ i: 1, e: 1 })
 
 /**
  * handle rm command
@@ -126,20 +146,37 @@ export async function handler (argv) {
   if (argv.help) {
     return 0
   }
-  const { /* glob, */ paths, connectionOptions } = argv
+  const { paths, connectionOptions, recursive, force, dryRun } = argv
+  const include = argv.include ?? []
+  const exclude = argv.exclude ?? []
 
-  // if (glob.includes('**')) {
-  //   console.error('Invalid value for option "glob"; "**" is not supported yet')
-  //   return 1
-  // }
+  const doubleWildcard = include.concat(exclude).find(pattern => pattern.includes('**'))
+  if (doubleWildcard) {
+    console.error(`Invalid pattern "${doubleWildcard}"; "**" is not supported yet`)
+    process.exit(1)
+  }
 
-  const normalized = paths.map(normalizePath)
+  const usePatterns = Boolean(include.length || exclude.length)
+  const normalized = paths.map(path => normalizeDbPath(assertAbsoluteDbPath(path)))
 
-  if (guardProtectedPaths(normalized)) {
+  // in pattern mode the given paths are the collections to search;
+  // each computed deletion is guarded against protected paths in the query
+  if (!usePatterns && guardProtectedPaths(normalized)) {
     return 1
   }
 
+  // an exclude-only pattern set removes everything that is not excluded
+  const includeGlobs = include.length ? include : ['*']
+
   const db = getXmlRpcClient(connectionOptions)
 
-  return rm(db, normalized, argv)
+  return rm(db, normalized, {
+    debug: argv.debug,
+    recursive,
+    force,
+    dryRun,
+    usePatterns,
+    includePatterns: usePatterns ? includeGlobs.map(toRegExpPattern) : [],
+    excludePatterns: usePatterns ? exclude.map(toRegExpPattern) : []
+  })
 }

--- a/commands/upload.js
+++ b/commands/upload.js
@@ -8,6 +8,7 @@ import { getXmlRpcClient, getMimeType } from '@existdb/node-exist'
 import { logFailure, logSuccess } from '../utility/message.js'
 import { formatErrorMessage, isNetworkError } from '../utility/errors.js'
 import { getServerUrl, getUserInfo } from '../utility/connection.js'
+import { stringList } from '../utility/options.js'
 
 /**
  * @typedef { import("../utility/account.js").AccountInfo } AccountInfo
@@ -22,15 +23,6 @@ import { getServerUrl, getUserInfo } from '../utility/connection.js'
  * @prop {Boolean} exists the collection exists
  * @prop {Boolean} created the collection was created
  */
-
-const stringList = {
-  type: 'string',
-  array: true,
-  coerce: (values) =>
-    values.length === 1 && values[0].trim() === 'false'
-      ? ['**']
-      : values.reduce((values, value) => values.concat(value.split(',').map((value) => value.trim())), [])
-}
 
 /**
  * Upload a single resource into an existdb instance

--- a/modules/rm.xq
+++ b/modules/rm.xq
@@ -3,11 +3,17 @@ xquery version "3.1";
 (: required parameter :)
 declare variable $paths as xs:string+ external;
 
+(: pattern matching - when empty, paths are removed as given :)
+declare variable $include-patterns as xs:string* external;
+declare variable $exclude-patterns as xs:string* external;
+
 (: options :)
-(: declare variable $glob as xs:string external; :)
-(: declare variable $dryrun as xs:boolean external; :)
+declare variable $dry-run as xs:boolean external;
 declare variable $recursive as xs:boolean external;
 declare variable $force as xs:boolean external;
+
+(: paths that must never be removed :)
+declare variable $protected-paths as xs:string* external;
 
 declare variable $COLLECTION := "collection";
 declare variable $RESOURCE := "resource";
@@ -20,24 +26,32 @@ declare function local:check-path ($path) {
     else error(xs:QName('not_available'), $path || " does not exist")
 };
 
-declare function local:remove($path) {
+declare function local:remove-resource ($path as xs:string) {
+    let $parts := tokenize($path, '/')
+    let $length := count($parts)
+    let $resource := $parts[$length]
+    let $collection := subsequence($parts, 1, $length - 1) => string-join('/')
+    return (xmldb:remove($collection, $resource), true())
+};
+
+declare function local:remove ($path) {
     switch(local:check-path($path))
         case $COLLECTION return
             if (not($recursive))
             then error(xs:QName('non_recursive'), $path || " is a collection, but the recursive option is not set")
             else if (not($force) and exists((xmldb:get-child-resources($path), xmldb:get-child-collections($path))))
             then error(xs:QName('not_empty'), $path || " is a non-empty collection, but the force option is not set")
+            else if ($dry-run)
+            then true()
             else (xmldb:remove($path), true())
-        case $RESOURCE return 
-            let $parts := tokenize($path, '/')
-            let $length := count($parts)
-            let $resource := $parts[$length]
-            let $collection := subsequence($parts, 1, $length - 1) => string-join('/')
-            return (xmldb:remove($collection, $resource), true())
+        case $RESOURCE return
+            if ($dry-run)
+            then true()
+            else local:remove-resource($path)
     default return error(xs:QName('unknown_type'), $path || " is of unknown type")
 };
 
-declare function local:safe-remove($path) {
+declare function local:safe-remove ($path) {
     try {
         map {
             "path": $path,
@@ -56,11 +70,149 @@ declare function local:safe-remove($path) {
     }
 };
 
+(:~ names are matched case-insensitively, excludes win over includes :)
+declare function local:name-matches ($name as xs:string) as xs:boolean {
+    (some $pattern in $include-patterns satisfies matches($name, $pattern, "i"))
+    and not(some $pattern in $exclude-patterns satisfies matches($name, $pattern, "i"))
+};
+
+(:~ collect matching children of $collection, descending only when $recursive is set :)
+declare function local:gather ($collection as xs:string) as map(*)* {
+    let $resources := xmldb:get-child-resources($collection)
+    let $collections := xmldb:get-child-collections($collection)
+    return (
+        for $resource in $resources
+        where local:name-matches($resource)
+        return map { "path": $collection || "/" || $resource, "type": $RESOURCE },
+        for $child in $collections
+        where local:name-matches($child)
+        return map { "path": $collection || "/" || $child, "type": $COLLECTION },
+        if ($recursive)
+        then
+            for $child in $collections
+            return local:gather($collection || "/" || $child)
+        else ()
+    )
+};
+
+declare function local:removed ($results as map(*)*, $path as xs:string) as xs:boolean {
+    some $result in $results satisfies ($result?path = $path and $result?success)
+};
+
+(:~
+ : A collection can go when every one of its current children was (or, in a
+ : dry run, would have been) removed by this query. Checking against the
+ : accumulated results keeps real runs and dry runs identical.
+ :)
+declare function local:collection-empty ($results as map(*)*, $path as xs:string) as xs:boolean {
+    every $child in (
+        (xmldb:get-child-resources($path), xmldb:get-child-collections($path))
+        ! ($path || "/" || .)
+    )
+    satisfies local:removed($results, $child)
+};
+
+declare function local:remove-matched-collection ($results as map(*)*, $path as xs:string) as map(*) {
+    if (not($recursive))
+    then map {
+        "path": $path,
+        "success": false(),
+        "skipped": true(),
+        "reason": "is a collection, but the recursive option is not set"
+    }
+    else if (not($force) and not(local:collection-empty($results, $path)))
+    then map {
+        "path": $path,
+        "success": false(),
+        "skipped": true(),
+        "reason": "is a non-empty collection, but the force option is not set"
+    }
+    else map {
+        "path": $path,
+        "success":
+            if ($dry-run)
+            then true()
+            else (xmldb:remove($path), true())
+    }
+};
+
+declare function local:remove-match ($results as map(*)*, $match as map(*)) as map(*) {
+    try {
+        if ($match?path = $protected-paths)
+        then map {
+            "path": $match?path,
+            "success": false(),
+            "error": map {
+                "description": $match?path || " is a protected path",
+                "code": "protected"
+            }
+        }
+        else if ($match?type = $RESOURCE)
+        then map {
+            "path": $match?path,
+            "success":
+                if ($dry-run)
+                then true()
+                else local:remove-resource($match?path)
+        }
+        else local:remove-matched-collection($results, $match?path)
+    }
+    catch * {
+        map {
+            "path": $match?path,
+            "success": false(),
+            "error": map {
+                "description": $err:description,
+                "code": $err:code
+            }
+        }
+    }
+};
+
+(:~
+ : Remove everything below the given base collections that matches the
+ : patterns. Deletions run deepest-first so that collections emptied by
+ : earlier removals can be removed on the way up.
+ :)
+declare function local:remove-matches () as map(*)* {
+    let $unavailable :=
+        for $base in $paths[not(xmldb:collection-available(.))]
+        return map {
+            "path": $base,
+            "success": false(),
+            "error": map {
+                "description": $base || " is not an available collection",
+                "code": "not_available"
+            }
+        }
+    let $matches :=
+        for $base in $paths[xmldb:collection-available(.)]
+        return local:gather($base)
+    let $deepest-first :=
+        for $match in $matches
+        order by count(tokenize($match?path, '/')) descending, $match?path ascending
+        return $match
+    return (
+        $unavailable,
+        fold-left(
+            $deepest-first,
+            (),
+            function ($results, $match) {
+                ($results, local:remove-match($results, $match))
+            }
+        )
+    )
+};
+
 try {
     serialize(
         map{
-            "list": array:for-each(
-                array{ $paths }, local:safe-remove#1),
+            "list":
+                if (exists(($include-patterns, $exclude-patterns)))
+                then array { local:remove-matches() }
+                else array:for-each(
+                    array{ $paths }, local:safe-remove#1),
+            "dryRun": $dry-run,
             "recursive": $recursive,
             "force": $force
         },

--- a/readme.md
+++ b/readme.md
@@ -121,6 +121,55 @@ xst get /db/apps/dashboard .
 The above downloads the contents of the collection `/db/apps/dashboard` into the
 `dashboard` folder in the current working directory.
 
+#### Remove collections and resources
+
+Remove a single resource:
+
+```bash
+xst rm /db/apps/myapp/controller.xql
+```
+
+With `--include` and `--exclude` the given paths become the collections to
+search and every child whose name matches one of the comma separated glob
+patterns is removed instead. Patterns are matched against resource and
+collection names case-insensitively, `*` never crosses `/` and `**` is not
+supported (yet).
+
+Remove all JavaScript resources directly in a collection:
+
+```bash
+xst rm /db/apps/myapp --include "*.js"
+```
+
+Remove all temporary resources and collections in the entire collection tree:
+
+```bash
+xst rm --recursive --include "temp-*" /db/apps/myapp
+```
+
+Rules:
+
+- `--exclude` wins over `--include`. Using `--exclude` on its own implies
+  `--include "*"`.
+- Without `--recursive` only direct children of the given collections are
+  inspected.
+- Matches are removed deepest first. Collections that (would) still have
+  contents are skipped unless `--force` is set.
+- Protected system paths such as `/db/system` are never removed, even when a
+  pattern matches them.
+- When nothing matched, the exit code is 9.
+
+> **Warning**
+> `remove` is destructive and there is no undo! A pattern that matches more
+> than you thought — especially combined with `--recursive` and `--force` —
+> can wipe out entire collection trees. Preview every pattern removal with
+> `--dry-run` (`-d`) first: it performs the exact same traversal and lists
+> what would be removed without touching anything.
+
+```bash
+xst rm --dry-run --recursive --include "temp-*" /db/apps/myapp
+```
+
 #### Set the permission for a resource
 
 This demonstrates how you can extend the current functionality by running arbitrary

--- a/spec/test.js
+++ b/spec/test.js
@@ -1,8 +1,45 @@
 import { spawn } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
 
 /**
  * @typedef {Promise<{stderr?: string, stdout?: string, code: number}>} CommandResult
  */
+
+// ---------------------------------------------------------------------------
+// Test target resolution
+//
+// The suite always tests the CLI of THIS checkout by spawning
+// `node <checkout>/cli.js` — never a globally installed or npm-linked xst.
+// This makes `npm test` safe in git worktrees: each worktree tests its own
+// code. Set XST_TEST_BIN to test a packaged binary instead (e.g. ./xst-linux).
+// ---------------------------------------------------------------------------
+const cliPath = fileURLToPath(new URL('../cli.js', import.meta.url))
+const testBin = process.env.XST_TEST_BIN
+
+function resolveXst (cmd, args = []) {
+  if (cmd !== 'xst') { return [cmd, args] }
+  if (testBin) { return [testBin, args] }
+  return [process.execPath, [cliPath, ...args]]
+}
+
+// ---------------------------------------------------------------------------
+// Test server resolution
+//
+// Defaults match CI: an eXist-db instance with its HTTPS/HTTP ports published
+// on localhost:8443/8080. To run the suite against an isolated instance (e.g.
+// per-worktree containers on other ports) set
+//
+//   XST_TEST_SERVER=https://localhost:11291 \
+//   XST_TEST_HTTP_SERVER=http://localhost:10291 npm test
+//
+// When XST_TEST_SERVER is set it is injected as EXISTDB_SERVER into every
+// spawned process; suites that specifically test connection *defaults*
+// (spec/tests/configuration.js) skip themselves in that case.
+// ---------------------------------------------------------------------------
+export const isIsolated = Boolean(process.env.XST_TEST_SERVER)
+export const testServer = process.env.XST_TEST_SERVER || 'https://localhost:8443'
+export const testHttpServer = process.env.XST_TEST_HTTP_SERVER || 'http://localhost:8080'
+const serverEnv = isIsolated ? { EXISTDB_SERVER: testServer } : {}
 
 /**
  * Run an shell command
@@ -13,10 +50,11 @@ import { spawn } from 'node:child_process'
  * @returns {CommandResult} The result of running the command
  */
 export async function run (cmd, args, options = cleanEnv) {
+  const [command, commandArgs] = resolveXst(cmd, args)
   return new Promise((resolve, reject) => {
     let stderr
     let stdout
-    const proc = spawn(cmd, args, options)
+    const proc = spawn(command, commandArgs, options)
     proc.stdout.on('data', (data) => {
       stdout ? (stdout += data.toString()) : (stdout = data.toString())
     })
@@ -45,11 +83,13 @@ export async function run (cmd, args, options = cleanEnv) {
  * @returns {CommandResult} The result of the pipe
  */
 export async function runPipe (cmd1, args1, cmd2, args2, options = cleanEnv) {
+  const [command1, commandArgs1] = resolveXst(cmd1, args1)
+  const [command2, commandArgs2] = resolveXst(cmd2, args2)
   return new Promise((resolve, reject) => {
     let stderr
     let stdout
-    const proc1 = spawn(cmd1, args1, options)
-    const proc2 = spawn(cmd2, args2, options)
+    const proc1 = spawn(command1, commandArgs1, options)
+    const proc2 = spawn(command2, commandArgs2, options)
     proc1.stdout.pipe(proc2.stdin)
 
     proc2.stdout.on('data', (data) => {
@@ -68,14 +108,14 @@ export async function runPipe (cmd1, args1, cmd2, args2, options = cleanEnv) {
 // guard test execution against environment variables in development setups
 const { EXISTDB_PASS, EXISTDB_USER, EXISTDB_SERVER, ...filteredEnv } = process.env
 export const cleanEnv = {
-  env: filteredEnv
+  env: { ...filteredEnv, ...serverEnv }
 }
 export const asGuest = {
-  env: { ...filteredEnv, EXISTDB_USER: 'guest', EXISTDB_PASS: 'guest' }
+  env: { ...filteredEnv, ...serverEnv, EXISTDB_USER: 'guest', EXISTDB_PASS: 'guest' }
 }
 export const asAdmin = {
-  env: { ...filteredEnv, EXISTDB_USER: 'admin', EXISTDB_PASS: '' }
+  env: { ...filteredEnv, ...serverEnv, EXISTDB_USER: 'admin', EXISTDB_PASS: '' }
 }
 export function forceColorLevel (level) {
-  return { env: { ...filteredEnv, FORCE_COLOR: level } }
+  return { env: { ...filteredEnv, ...serverEnv, FORCE_COLOR: level } }
 }

--- a/spec/test.js
+++ b/spec/test.js
@@ -41,6 +41,14 @@ export const testServer = process.env.XST_TEST_SERVER || 'https://localhost:8443
 export const testHttpServer = process.env.XST_TEST_HTTP_SERVER || 'http://localhost:8080'
 const serverEnv = isIsolated ? { EXISTDB_SERVER: testServer } : {}
 
+// Some suites (spec/tests/exec.js) run command handlers in-process via the
+// yargs parser instead of spawning the CLI; those read process.env directly.
+// Inject the override into this process too, so in-process tests hit the
+// same isolated instance as spawned ones.
+if (isIsolated) {
+  process.env.EXISTDB_SERVER = testServer
+}
+
 /**
  * Run an shell command
  *

--- a/spec/tests/configuration.js
+++ b/spec/tests/configuration.js
@@ -1,7 +1,13 @@
 import { test } from 'tape'
-import { run, asAdmin, cleanEnv } from '../test.js'
+import { run, asAdmin, cleanEnv, isIsolated } from '../test.js'
 
-test('no config file or env variables defaults to guest user', async function (t) {
+// This suite tests connection *defaults* and fixture config files, all of
+// which pin the default ports (8443/8080). When the suite is pointed at an
+// isolated instance via XST_TEST_SERVER these tests cannot pass and are
+// skipped — they still run in CI and in default local runs.
+const opts = { skip: isIsolated }
+
+test('no config file or env variables defaults to guest user', opts, async function (t) {
   const { stderr, stdout } = await run('xst', ['exec', '-f', 'modules/whoami.xq'])
   if (stderr) {
     return t.fail(stderr)
@@ -13,7 +19,7 @@ test('no config file or env variables defaults to guest user', async function (t
   t.end()
 })
 
-test('read config file', async function (t) {
+test('read config file', opts, async function (t) {
   const { stderr, stdout } = await run('xst', ['exec', '--config', 'spec/fixtures/.xstrc', '-f', 'modules/whoami.xq'])
   if (stderr) {
     return t.fail(stderr)
@@ -25,7 +31,7 @@ test('read config file', async function (t) {
   t.end()
 })
 
-test('reads environment variables', async function (t) {
+test('reads environment variables', opts, async function (t) {
   const { stderr, stdout } = await run('xst', ['exec', '-f', 'modules/whoami.xq'], asAdmin)
   if (stderr) {
     return t.fail(stderr)
@@ -37,7 +43,7 @@ test('reads environment variables', async function (t) {
   t.end()
 })
 
-test('reads configuration from .env', async function (t) {
+test('reads configuration from .env', opts, async function (t) {
   const { stderr, stdout } = await run('xst', ['exec', '--config', 'spec/fixtures/.env', '-f', 'modules/whoami.xq'])
   if (stderr) {
     return t.fail(stderr)
@@ -49,7 +55,7 @@ test('reads configuration from .env', async function (t) {
   t.end()
 })
 
-test('reads configuration from .env.staging', async function (t) {
+test('reads configuration from .env.staging', opts, async function (t) {
   const { stderr, stdout } = await run('xst', ['exec', '--config', 'spec/fixtures/.env.staging', '-f', 'modules/whoami.xq'])
   if (stderr) {
     return t.fail(stderr)
@@ -61,7 +67,7 @@ test('reads configuration from .env.staging', async function (t) {
   t.end()
 })
 
-test('reads connection from .existdb.json', async function (t) {
+test('reads connection from .existdb.json', opts, async function (t) {
   const { stderr, stdout } = await run('xst', ['exec', '--config', 'spec/fixtures/.existdb.json', '-f', 'modules/whoami.xq'])
   if (stderr) {
     return t.fail(stderr)
@@ -73,7 +79,7 @@ test('reads connection from .existdb.json', async function (t) {
   t.end()
 })
 
-test('connection options set in configuration overrides environment variables', async function (t) {
+test('connection options set in configuration overrides environment variables', opts, async function (t) {
   const { stderr, stdout } = await run('xst', ['exec', '--config', 'spec/fixtures/.env', '-f', 'modules/whoami.xq'], asAdmin)
   if (stderr) {
     return t.fail(stderr)
@@ -85,14 +91,14 @@ test('connection options set in configuration overrides environment variables', 
   t.end()
 })
 
-test('fail if config file was not found', async function (t) {
+test('fail if config file was not found', opts, async function (t) {
   const { stderr, stdout } = await run('xst', ['exec', '--config', 'non-existent.file', '-f', 'modules/whoami.xq'], asAdmin)
   if (stdout) return t.fail(stdout)
   t.ok(stderr, stderr)
   t.end()
 })
 
-test('configuration cascade', function (st) {
+test('configuration cascade', opts, function (st) {
   st.test('connection.xstrc fails to connect (certificate expired)', async function (t) {
     const { stderr, stdout } = await run('xst', ['exec', '--config', 'spec/fixtures/connection.xstrc', '-f', 'modules/whoami.xq', '--verbose'])
     const lines = stderr.split('\n')

--- a/spec/tests/exec.js
+++ b/spec/tests/exec.js
@@ -1,12 +1,18 @@
 import { test } from 'tape'
 import yargs from 'yargs'
 import * as exec from '../../commands/exec.js'
+import { readConnection } from '../../utility/connection.js'
 import { runPipe } from '../test.js'
 
-// a yargs instance must not be reused across parses: on a reused instance a
+// Mirror cli.js: resolve connection options from the environment so in-process
+// handlers connect to the same instance as spawned ones (the isolated server
+// under XST_TEST_SERVER, or the CI default otherwise). Without this the handler
+// falls back to node-exist's hardcoded default and, under isolation, floods an
+// uncaught ECONNREFUSED that crashes the suite.
+// A yargs instance must not be reused across parses: on a reused instance a
 // boolean option next to the positional (e.g. `execute --stats 1+1`) silently
-// drops the positional, so each parse gets a fresh parser
-const parser = () => yargs().scriptName('xst').command(exec).help().fail(false)
+// drops the positional, so each parse gets a fresh parser.
+const parser = () => yargs().scriptName('xst').command(exec).middleware(readConnection).help().fail(false)
 
 const execCmd = async (cmd, args) => {
   return await yargs()

--- a/spec/tests/get.js
+++ b/spec/tests/get.js
@@ -182,12 +182,12 @@ test('with test collection', async (t) => {
 
     // files are not downloaded in reproducible order
     st.equal(
-      lines.filter((l) => /^✔︎ created directory [/\w]+\/get-test/.exec(l)).length,
+      lines.filter((l) => /^✔︎ created directory [/.\w-]+\/get-test/.exec(l)).length,
       3,
       'notify 3 directories created'
     )
     st.equal(
-      lines.filter((l) => /^✔︎ downloaded resource [/\w]+\/get-test/.exec(l)).length,
+      lines.filter((l) => /^✔︎ downloaded resource [/.\w-]+\/get-test/.exec(l)).length,
       10,
       'notify 10 resources downloaded'
     )

--- a/spec/tests/get.js
+++ b/spec/tests/get.js
@@ -1,5 +1,5 @@
 import { test } from 'tape'
-import { run, asAdmin } from '../test.js'
+import { run, asAdmin, testServer } from '../test.js'
 import { readdirSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
@@ -172,7 +172,7 @@ test('with test collection', async (t) => {
     const { stderr, stdout } = await run('xst', ['get', '--verbose', testCollection, '.'], asAdmin)
     st.plan(9)
     const verboseLines = stderr.split('\n')
-    st.equal(verboseLines[0], 'Connecting to https://localhost:8443 as admin', verboseLines[0])
+    st.equal(verboseLines[0], `Connecting to ${testServer} as admin`, verboseLines[0])
     st.ok(verboseLines[1].startsWith('Downloading /db/get-test to'), verboseLines[1])
     st.equal(verboseLines[2], 'Downloading up to 4 resources at a time', verboseLines[2])
     st.equal(verboseLines[3], '', verboseLines[3])

--- a/spec/tests/info.js
+++ b/spec/tests/info.js
@@ -1,5 +1,5 @@
 import { test } from 'tape'
-import { run, asAdmin } from '../test.js'
+import { run, asAdmin, testServer } from '../test.js'
 
 test("calling 'xst info'", async (t) => {
   const { stderr, stdout } = await run('xst', ['info'])
@@ -16,7 +16,7 @@ test("calling 'xst info'", async (t) => {
 test("calling 'xst info --verbose'", async (t) => {
   const { stderr, stdout } = await run('xst', ['info', '--verbose'])
   t.plan(5)
-  t.equal(stderr, 'Connecting to https://localhost:8443 as guest\n', 'connection and user output on stderr')
+  t.equal(stderr, `Connecting to ${testServer} as guest\n`, 'connection and user output on stderr')
 
   const lines = stdout.split('\n')
   t.equal(lines.length, 4, 'outputs four lines')

--- a/spec/tests/package/install/registry.js
+++ b/spec/tests/package/install/registry.js
@@ -1,6 +1,8 @@
 import { readFile } from 'node:fs/promises'
 import test from 'tape'
-import { run, asAdmin } from '../../../test.js'
+import { run, asAdmin, testHttpServer } from '../../../test.js'
+
+const publicRepo = `${testHttpServer}/exist/apps/public-repo`
 
 const testAppName = 'http://exist-db.org/apps/test-app'
 const testLibName = 'http://exist-db.org/apps/test-lib'
@@ -33,8 +35,13 @@ async function cleanup (t) {
 }
 
 async function isLocalRepoAvailable () {
-  const { status } = await fetch('http://localhost:8080/exist/apps/public-repo')
-  return status === 200
+  try {
+    const { status } = await fetch(publicRepo)
+    return status === 200
+  } catch (_) {
+    // connection refused — no instance (or no public-repo) on this port
+    return false
+  }
 }
 
 /**
@@ -49,9 +56,8 @@ async function installPackageToLocalRepo (t) {
     formData.append('files[]', blob, app)
     formData.append('', '\\')
 
-    // TODO: Read in localhost
     const { status } = await fetch(
-      'http://localhost:8080/exist/apps/public-repo/publish',
+      `${publicRepo}/publish`,
       {
         method: 'post',
         headers: {
@@ -122,7 +128,7 @@ test('Work with a local public registry', async function (t) {
       'install',
       'registry',
       '--registry',
-      'http://localhost:8080/exist/apps/public-repo',
+      publicRepo,
       testAppName
     ])
     st.equal(
@@ -145,7 +151,7 @@ test('Work with a local public registry', async function (t) {
           'install',
           'registry',
           '--registry',
-          'http://localhost:8080/exist/apps/public-repo',
+          publicRepo,
           testAppName
         ],
         asAdmin
@@ -173,7 +179,7 @@ test('Work with a local public registry', async function (t) {
           'install',
           'registry',
           '--registry',
-          'http://localhost:8080/exist/apps/public-repo',
+          publicRepo,
           'test-app'
         ],
         asAdmin
@@ -222,7 +228,7 @@ test('Work with a local public registry', async function (t) {
           'install',
           'registry',
           '--registry',
-          'http://localhost:8080/exist/apps/public-repo',
+          publicRepo,
           testAppName,
           '1.0.1'
         ],
@@ -248,7 +254,7 @@ test('Work with a local public registry', async function (t) {
         'install',
         'registry',
         '--registry',
-        'http://localhost:8080/exist/apps/public-repo',
+        publicRepo,
         testAppName,
         '1.0.1',
         '--force'
@@ -279,7 +285,7 @@ test('Work with a local public registry', async function (t) {
           'install',
           'registry',
           '--registry',
-          'http://localhost:8080/exist/apps/public-repo',
+          publicRepo,
           testAppName,
           '10.98.2'
         ],
@@ -308,7 +314,7 @@ test('Work with a local public registry', async function (t) {
           'install',
           'registry',
           '--registry',
-          'http://localhost:8080/doesnotexist/',
+          `${testHttpServer}/doesnotexist/`,
           testAppName
         ],
         asAdmin
@@ -319,7 +325,7 @@ test('Work with a local public registry', async function (t) {
       // @todo: maybe a better error here? Explain user what actually went wrong?
       st.equal(
         stderr,
-        '✘ http://exist-db.org/apps/test-app > Server responded with a Servlet error. Probably a wrong path to the public-repo or public-repo not installed. Please check the URL http://localhost:8080/doesnotexist/\n',
+        `✘ http://exist-db.org/apps/test-app > Server responded with a Servlet error. Probably a wrong path to the public-repo or public-repo not installed. Please check the URL ${testHttpServer}/doesnotexist/\n`,
         stderr
       )
       st.end()

--- a/spec/tests/package/list.js
+++ b/spec/tests/package/list.js
@@ -1,5 +1,5 @@
 import { test } from 'tape'
-import { run, asAdmin } from '../../test.js'
+import { run, asAdmin, testServer } from '../../test.js'
 
 const testAppName = 'http://exist-db.org/apps/test-app'
 const testLibName = 'http://exist-db.org/apps/test-lib'
@@ -86,7 +86,7 @@ test.skip('sorts by type and installation date', async function (t) {
 
   if (stderr) { return t.fail(stderr) }
   const lines = stdout.split('\n')
-  t.equal(lines[0], 'Install test-app.xar on https://localhost:8443')
+  t.equal(lines[0], `Install test-app.xar on ${testServer}`)
 })
 
 test('with new package', async function (t) {

--- a/spec/tests/rm.js
+++ b/spec/tests/rm.js
@@ -2,6 +2,7 @@ import { test } from 'tape'
 import { run, asAdmin } from '../test.js'
 
 const testCollection = '/db/rm-test'
+const globCollection = '/db/rm-glob-test'
 
 async function ensureCollectionIsRemoved (t) {
   const { stderr, stdout } = await run('xst', ['ls', testCollection])
@@ -27,6 +28,39 @@ async function prepare (t) {
   t.end()
 }
 
+/**
+ * fixture tree for pattern matching tests
+ *
+ * /db/rm-glob-test
+ * ├── a.xml
+ * ├── b.xml
+ * ├── c.txt
+ * ├── temp-1.txt
+ * ├── data
+ * │   ├── d.xml
+ * │   ├── temp-2.txt
+ * │   └── temp-sub (empty collection)
+ * └── temp-keep
+ *     └── keep.txt
+ */
+async function prepareGlobFixtures (t) {
+  const query = [
+    'xmldb:create-collection("/db", "rm-glob-test")',
+    `xmldb:create-collection("${globCollection}", "data")`,
+    `xmldb:create-collection("${globCollection}/data", "temp-sub")`,
+    `xmldb:create-collection("${globCollection}", "temp-keep")`,
+    storeResourceQuery(globCollection, 'a.xml', '<a />'),
+    storeResourceQuery(globCollection, 'b.xml', '<b />'),
+    storeResourceQuery(globCollection, 'c.txt', '"c"'),
+    storeResourceQuery(globCollection, 'temp-1.txt', '"t1"'),
+    storeResourceQuery(globCollection + '/data', 'd.xml', '<d />'),
+    storeResourceQuery(globCollection + '/data', 'temp-2.txt', '"t2"'),
+    storeResourceQuery(globCollection + '/temp-keep', 'keep.txt', '"keep"')
+  ].join(',')
+  const { stderr } = await run('xst', ['run', query], asAdmin)
+  if (stderr) { t.fail(stderr) }
+}
+
 function storeResourceQuery (collection, fileName, content) {
   return `xmldb:store("${collection}", "${fileName}", ${content})`
 }
@@ -36,6 +70,18 @@ test("calling 'xst rm --help'", async (t) => {
   if (stderr) { return t.fail(stderr) }
 
   t.ok(stdout, stdout)
+  t.ok(stdout.includes('--include'), 'shows include option')
+  t.ok(stdout.includes('--exclude'), 'shows exclude option')
+  t.ok(stdout.includes('--dry-run'), 'shows dry-run option')
+  t.end()
+})
+
+test('relative paths are rejected with a hint', async (t) => {
+  const { stderr, stdout, code } = await run('xst', ['rm', 'rm-test'], asAdmin)
+
+  if (stdout) { return t.fail(stdout) }
+  t.equal(code, 1, 'exit code 1')
+  t.ok(stderr.includes('Invalid path "rm-test": database paths must be absolute. Did you mean "/db/rm-test"?'), stderr)
   t.end()
 })
 
@@ -61,7 +107,9 @@ test('admin cannot remove protected paths', async (t) => {
       const { stderr, stdout } = await run('xst', ['rm', '-rf', p], asAdmin)
 
       if (stdout) { return st.fail(stdout) }
-      const path = p !== '/' && p.endsWith('/') ? p.substring(0, p.length - 1) : p
+      // "/" is an alias for "/db", trailing slashes are stripped
+      let path = p === '/' ? '/db' : p
+      path = path !== '/' && path.endsWith('/') ? path.substring(0, path.length - 1) : path
 
       st.equal(stderr, `Cannot remove protected path: ${path}\n`, stderr)
       st.end()
@@ -127,4 +175,129 @@ test('with test collection', async (t) => {
   })
 
   t.teardown(ensureCollectionIsRemoved)
+})
+
+test('with glob patterns', async (t) => {
+  t.test('--include "*.xml" removes only matching resources at the top level', async (st) => {
+    await prepareGlobFixtures(st)
+    const { stderr, stdout, code } = await run('xst', ['rm', globCollection, '--include', '*.xml'], asAdmin)
+
+    if (stderr) { return st.fail(stderr) }
+    st.equal(code, 0, 'exit code 0')
+    st.equal(stdout,
+      `✔︎ ${globCollection}/a.xml\n` +
+      `✔︎ ${globCollection}/b.xml\n`,
+      'removed only top-level xml resources')
+
+    const { stdout: lsRoot } = await run('xst', ['ls', globCollection], asAdmin)
+    st.notOk(lsRoot.includes('a.xml'), 'a.xml is gone')
+    st.notOk(lsRoot.includes('b.xml'), 'b.xml is gone')
+    st.ok(lsRoot.includes('c.txt'), 'c.txt was kept')
+    st.ok(lsRoot.includes('data'), 'data collection was kept')
+    const { stdout: lsData } = await run('xst', ['ls', globCollection + '/data'], asAdmin)
+    st.ok(lsData.includes('d.xml'), 'd.xml below the top level was not touched')
+    st.end()
+  })
+
+  t.test('--recursive --include "temp-*" removes matches at depth, deepest first', async (st) => {
+    await prepareGlobFixtures(st)
+    const { stderr, stdout, code } = await run('xst', ['rm', '--recursive', '--include', 'temp-*', globCollection], asAdmin)
+
+    if (stderr) { return st.fail(stderr) }
+    st.equal(code, 0, 'exit code 0')
+    st.equal(stdout,
+      `✔︎ ${globCollection}/data/temp-2.txt\n` +
+      `✔︎ ${globCollection}/data/temp-sub\n` +
+      `✔︎ ${globCollection}/temp-1.txt\n` +
+      `- ${globCollection}/temp-keep - is a non-empty collection, but the force option is not set\n`,
+      'deepest matches first, non-empty collection skipped')
+
+    const { stdout: lsKeep } = await run('xst', ['ls', globCollection + '/temp-keep'], asAdmin)
+    st.ok(lsKeep.includes('keep.txt'), 'contents of the skipped collection were not touched')
+    st.end()
+  })
+
+  t.test('--exclude wins over --include', async (st) => {
+    await prepareGlobFixtures(st)
+    const { stderr, stdout, code } = await run('xst', ['rm', globCollection, '--include', '*.txt', '--exclude', 'temp-*'], asAdmin)
+
+    if (stderr) { return st.fail(stderr) }
+    st.equal(code, 0, 'exit code 0')
+    st.equal(stdout, `✔︎ ${globCollection}/c.txt\n`, 'only the non-excluded resource was removed')
+
+    const { stdout: lsRoot } = await run('xst', ['ls', globCollection], asAdmin)
+    st.ok(lsRoot.includes('temp-1.txt'), 'excluded resource was kept')
+    st.end()
+  })
+
+  t.test('--exclude on its own implies --include "*"', async (st) => {
+    await prepareGlobFixtures(st)
+    const { stderr, stdout, code } = await run('xst', ['rm', '--dry-run', globCollection, '--exclude', '*.xml'], asAdmin)
+
+    if (stderr) { return st.fail(stderr) }
+    st.equal(code, 0, 'exit code 0')
+    st.equal(stdout,
+      `would remove: ${globCollection}/c.txt\n` +
+      `- ${globCollection}/data - is a collection, but the recursive option is not set\n` +
+      `would remove: ${globCollection}/temp-1.txt\n` +
+      `- ${globCollection}/temp-keep - is a collection, but the recursive option is not set\n`,
+      'everything but the excluded resources would be removed')
+    st.end()
+  })
+
+  t.test('--dry-run lists would-be deletions without removing anything', async (st) => {
+    await prepareGlobFixtures(st)
+    const { stderr, stdout, code } = await run('xst', ['rm', '--dry-run', '--recursive', '--include', 'temp-*', globCollection], asAdmin)
+
+    if (stderr) { return st.fail(stderr) }
+    st.equal(code, 0, 'exit code 0')
+    st.equal(stdout,
+      `would remove: ${globCollection}/data/temp-2.txt\n` +
+      `would remove: ${globCollection}/data/temp-sub\n` +
+      `would remove: ${globCollection}/temp-1.txt\n` +
+      `- ${globCollection}/temp-keep - is a non-empty collection, but the force option is not set\n`,
+      'identical traversal to a real run')
+
+    const { stdout: lsRoot } = await run('xst', ['ls', globCollection], asAdmin)
+    st.ok(lsRoot.includes('temp-1.txt'), 'nothing was removed at the top level')
+    const { stdout: lsData } = await run('xst', ['ls', globCollection + '/data'], asAdmin)
+    st.ok(lsData.includes('temp-2.txt'), 'nothing was removed at depth')
+    st.ok(lsData.includes('temp-sub'), 'no collection was removed')
+    st.end()
+  })
+
+  t.test('pattern matching a protected path is skipped with an error line', async (st) => {
+    const { stderr, stdout, code } = await run('xst', ['rm', '/db', '--include', 'apps'], asAdmin)
+
+    if (stdout) { return st.fail(stdout) }
+    st.equal(code, 0, 'exit code 0')
+    st.equal(stderr, '✘ /db/apps - /db/apps is a protected path\n', stderr)
+
+    const { stderr: lsErr } = await run('xst', ['ls', '/db/apps'], asAdmin)
+    st.notOk(lsErr, '/db/apps is still available')
+    st.end()
+  })
+
+  t.test('pattern with "**" is rejected', async (st) => {
+    const { stderr, stdout, code } = await run('xst', ['rm', globCollection, '--include', '**/*.xml'], asAdmin)
+
+    if (stdout) { return st.fail(stdout) }
+    st.equal(code, 1, 'exit code 1')
+    st.equal(stderr, 'Invalid pattern "**/*.xml"; "**" is not supported yet\n', stderr)
+    st.end()
+  })
+
+  t.test('nothing matched exits with code 9', async (st) => {
+    await prepareGlobFixtures(st)
+    const { stderr, stdout, code } = await run('xst', ['rm', globCollection, '--include', 'no-such-thing-*'], asAdmin)
+
+    if (stdout) { return st.fail(stdout) }
+    st.equal(code, 9, 'exit code 9')
+    st.equal(stderr, 'Nothing matched\n', stderr)
+    st.end()
+  })
+
+  t.teardown(async () => {
+    await run('xst', ['rm', '-rf', globCollection], asAdmin)
+  })
 })

--- a/spec/tests/upload.js
+++ b/spec/tests/upload.js
@@ -1,5 +1,5 @@
 import { test } from 'tape'
-import { run, asAdmin } from '../test.js'
+import { run, asAdmin, testServer } from '../test.js'
 
 const testCollection = '/db/upload-test'
 
@@ -41,7 +41,7 @@ test('uploading files and folders', function (t) {
     const { stderr, stdout, code } = await run('xst', ['up', '-v', 'spec/test.js', testCollection])
     st.equal(code, 1, 'exit code 1')
     const lines = stderr.split('\n')
-    st.equal(lines[0], 'Connecting to https://localhost:8443 as guest', lines[0])
+    st.equal(lines[0], `Connecting to ${testServer} as guest`, lines[0])
     st.equal(lines[1], '✘ test.js Error: Write permission is not granted on the Collection.', lines[1])
     st.ok(/Upload of .+?spec\/test\.js failed\./.test(lines[2]), lines[2])
     st.ok(stdout, 'additional info is displayed')
@@ -72,7 +72,7 @@ test('uploading files and folders', function (t) {
     const { stderr, stdout, code } = await run('xst', ['up', '-v', 'spec/fixtures/test.xq', testCollection])
     st.equal(code, 1, 'exit code 1')
     const lines = stderr.split('\n')
-    st.equal(lines[0], 'Connecting to https://localhost:8443 as guest', lines[0])
+    st.equal(lines[0], `Connecting to ${testServer} as guest`, lines[0])
     st.equal(lines[1], '✘ test.xq Error: A resource with the same name already exists in the target collection \'/db/upload-test\', and you do not have write access on that resource.')
     st.ok(/Upload of .+?spec\/fixtures\/test\.xq failed\./.test(lines[2]))
     st.ok(stdout, 'additional info is displayed')

--- a/spec/tests/utility/db-path.js
+++ b/spec/tests/utility/db-path.js
@@ -1,0 +1,54 @@
+import { test } from 'tape'
+import { assertAbsoluteDbPath, normalizeDbPath } from '../../../utility/db-path.js'
+
+test('assertAbsoluteDbPath', function (t) {
+  t.test('accepts absolute paths', function (st) {
+    st.equals(assertAbsoluteDbPath('/db'), '/db')
+    st.equals(assertAbsoluteDbPath('/'), '/')
+    st.equals(assertAbsoluteDbPath('/db/apps/'), '/db/apps/')
+    st.end()
+  })
+
+  t.test('rejects relative paths with a hint', function (st) {
+    st.throws(
+      () => assertAbsoluteDbPath('my/collection'),
+      /Did you mean "\/db\/my\/collection"\?/,
+      'plain relative path hints /db prefix')
+    st.throws(
+      () => assertAbsoluteDbPath('db/apps'),
+      /Did you mean "\/db\/apps"\?/,
+      'path starting with db/ hints leading slash only')
+    st.throws(
+      () => assertAbsoluteDbPath('db'),
+      /Did you mean "\/db"\?/,
+      'bare db hints /db')
+    st.end()
+  })
+
+  t.test('rejects empty and non-string values', function (st) {
+    st.throws(() => assertAbsoluteDbPath(''), /non-empty/)
+    st.throws(() => assertAbsoluteDbPath(undefined), /non-empty/)
+    st.throws(() => assertAbsoluteDbPath(null), /non-empty/)
+    st.end()
+  })
+})
+
+test('normalizeDbPath', function (t) {
+  t.test('resolves / to /db', function (st) {
+    st.equals(normalizeDbPath('/'), '/db')
+    st.end()
+  })
+
+  t.test('strips trailing slashes', function (st) {
+    st.equals(normalizeDbPath('/db/'), '/db')
+    st.equals(normalizeDbPath('/db/apps///'), '/db/apps')
+    st.equals(normalizeDbPath('//'), '/db')
+    st.end()
+  })
+
+  t.test('leaves canonical paths untouched', function (st) {
+    st.equals(normalizeDbPath('/db'), '/db')
+    st.equals(normalizeDbPath('/db/apps'), '/db/apps')
+    st.end()
+  })
+})

--- a/utility/db-path.js
+++ b/utility/db-path.js
@@ -1,0 +1,45 @@
+/**
+ * Shared handling of database collection and resource paths.
+ *
+ * Semantics:
+ * - database paths must be absolute (leading slash)
+ * - "/" is an alias for "/db", the root collection
+ * - trailing slashes are ignored
+ */
+
+/**
+ * Ensure a database path is absolute.
+ * Throws with a helpful hint otherwise.
+ * @param {String} path database path
+ * @returns {String} the path, unchanged
+ */
+export function assertAbsoluteDbPath (path) {
+  if (typeof path !== 'string' || path === '') {
+    throw Error('Invalid path: database paths must be non-empty strings.')
+  }
+  if (!path.startsWith('/')) {
+    const hint = path === 'db' || path.startsWith('db/')
+      ? '/' + path
+      : '/db/' + path
+    throw Error(
+      `Invalid path "${path}": database paths must be absolute. Did you mean "${hint}"?`)
+  }
+  return path
+}
+
+/**
+ * Canonicalize an absolute database path.
+ * Strips trailing slashes, resolves "/" to "/db".
+ * @param {String} path absolute database path
+ * @returns {String} normalized path
+ */
+export function normalizeDbPath (path) {
+  let normalized = path
+  while (normalized.length > 1 && normalized.endsWith('/')) {
+    normalized = normalized.substring(0, normalized.length - 1)
+  }
+  if (normalized === '/') {
+    return '/db'
+  }
+  return normalized
+}

--- a/utility/options.js
+++ b/utility/options.js
@@ -1,0 +1,17 @@
+/**
+ * shared yargs option helpers
+ */
+
+/**
+ * Option definition mixin for repeatable, comma-separated string list
+ * options (e.g. --include, --exclude).
+ * The single value "false" yields the match-all pattern ['**'].
+ */
+export const stringList = {
+  type: 'string',
+  array: true,
+  coerce: (values) =>
+    values.length === 1 && values[0].trim() === 'false'
+      ? ['**']
+      : values.reduce((values, value) => values.concat(value.split(',').map((value) => value.trim())), [])
+}


### PR DESCRIPTION
## Summary
- `xst rm` gains `--include`/`--exclude` glob matching: given paths become collections to search, and every child whose name matches a comma-separated glob pattern is removed server-side, deepest-first, in a single query.
- Safety semantics: `--dry-run` performs the identical traversal without touching anything; protected system paths are never removed even on a pattern match; non-empty collections are skipped unless `--force`, removed only with `--recursive`; patterns are case-insensitive, `*` does not cross `/`, `**` is rejected; `--exclude` wins over `--include`, and `--exclude` alone implies `--include '*'`; exit code 9 when nothing matches.
- `rm` also rejects relative database paths with a hint and canonicalizes `/` to `/db` (#319).
- Adds a shared `utility/db-path.js` helper (path validation/normalization, comma-separated list coercion) shared in preparation for #319 and #278.
- Test suite made worktree-safe and server-configurable (spawns the current checkout's `cli.js`, supports `XST_TEST_SERVER`/`XST_TEST_HTTP_SERVER` for isolated instances) so `npm test` reliably exercises this checkout.
- Fixes CLI usage output to always present `xst` as the program name regardless of launch path.

Closes #119

## Test plan
- [x] `npm test` passes locally
- [x] `xst rm --dry-run --include/--exclude` traversal manually verified against a test instance
- [x] Verified protected system paths are never removed even on pattern match
- [x] Verified exit code 9 when patterns match nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Pcjf9qyDX2PYu9vtXzGiH