### PR TITLE
fix: fail with a friendly error on unsupported Node.js versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ node_modules
 # artifacts
 *.tgz
 coverage
+
+# implementation plans (local only)
+plans/

--- a/app.js
+++ b/app.js
@@ -51,6 +51,7 @@ function showLogo () {
 }
 
 const parser = yargs(hideBin(process.argv))
+  .scriptName('xst')
   .config('config', 'Read configuration file', configure)
   .middleware(readConnection)
   .usageConfiguration({ 'hide-types': true })

--- a/app.js
+++ b/app.js
@@ -59,7 +59,7 @@ const parser = yargs(hideBin(process.argv))
   .strictCommands(true)
   .strictOptions(false)
   .help()
-  .command('$0 [<command>]', 'Interact with an eXist-db', () => {}, async (argv) => {
+  .command('$0 [<command>]', 'Interact with an eXist-db', yargs => yargs, async (argv) => {
     if (argv.command) {
       console.error(`Command "${argv.command}" not recognized.
 Try xst --help`)

--- a/app.js
+++ b/app.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+
+import yargs from 'yargs'
+import chalk from 'chalk'
+import { commands } from './commands/index.js'
+import { handleError } from './utility/errors.js'
+import { hideBin } from 'yargs/helpers'
+import { readConnection } from './utility/connection.js'
+import { configure } from './utility/configure.js'
+
+// colored terminal output
+const bb = chalk.blackBright
+const ma = chalk.magenta
+const rb = chalk.redBright
+const yl = chalk.yellow
+
+/**
+ * if package was linked to global strip relative path from output
+ * @param {String} $0 raw value of argv.$0
+ * @returns {String} script name with relative path stripped if linked
+ */
+function getScriptName ($0) {
+  if ($0.startsWith('.')) {
+    return $0.substring($0.lastIndexOf('/') + 1)
+  }
+  return $0
+}
+
+function showCompletionHelp (scriptName) {
+  console.log(`
+${bb('Install command completions for ZSH and BASH')}
+  ${scriptName} completion`)
+}
+
+function showExamples (scriptName) {
+  console.log(`
+${bb('Examples:')}
+  ${scriptName} run 'count(//p)'
+  ${scriptName} list --tree --depth 1 /db/apps
+  ${scriptName} package install from-registry demo-apps
+`)
+}
+
+function showLogo () {
+  console.log('\n' +
+    ma`  ╲ ╱  ╓───  ──┰──` + '\n' +
+    rb`   ╳   ╰───╮   │  ` + '\n' +
+    yl`  ╱ ╲  ▂▁▁▁│   ┇  ` + '\n'
+  )
+  console.log(yl`A modern command line interface for exist-db`)
+}
+
+const parser = yargs(hideBin(process.argv))
+  .config('config', 'Read configuration file', configure)
+  .middleware(readConnection)
+  .usageConfiguration({ 'hide-types': true })
+  .completion('completion', false)
+  .strictCommands(true)
+  .strictOptions(false)
+  .help()
+  .command('$0 [<command>]', 'Interact with an eXist-db', () => {}, async (argv) => {
+    if (argv.command) {
+      console.error(`Command "${argv.command}" not recognized.
+Try xst --help`)
+    }
+
+    showLogo()
+    const scriptName = getScriptName(argv.$0)
+    showCompletionHelp(scriptName)
+    // append examples
+    showExamples(scriptName)
+  })
+  .command(commands)
+  // .recommendCommands()
+  .fail(false)
+
+parser.wrap(parser.terminalWidth())
+
+try {
+  await parser.parse()
+} catch (error) {
+  handleError(error)
+  parser.getHelp()
+  process.exit(1)
+}

--- a/cli.js
+++ b/cli.js
@@ -51,6 +51,7 @@ function showLogo () {
 }
 
 const parser = yargs(hideBin(process.argv))
+  .scriptName('xst')
   .config('config', 'Read configuration file', configure)
   .middleware(readConnection)
   .usageConfiguration({ 'hide-types': true })

--- a/cli.js
+++ b/cli.js
@@ -4,11 +4,10 @@
 // able to fail with a friendly error message (see #291). Its static import
 // graph must contain no third-party code except 'semver' (CJS, runs on
 // ancient Node.js). The actual CLI is loaded via dynamic import below.
-import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
 import { isSupported } from './utility/node-version.js'
 
-const { engines } = JSON.parse(
-  readFileSync(new URL('./package.json', import.meta.url)))
+const { engines } = createRequire(import.meta.url)('./package.json')
 
 if (!isSupported(process.versions.node, engines.node)) {
   console.error(

--- a/cli.js
+++ b/cli.js
@@ -1,86 +1,34 @@
 #!/usr/bin/env node
 
-import yargs from 'yargs'
-import chalk from 'chalk'
-import { commands } from './commands/index.js'
-import { handleError } from './utility/errors.js'
-import { hideBin } from 'yargs/helpers'
-import { readConnection } from './utility/connection.js'
-import { configure } from './utility/configure.js'
+// This launcher must parse and run on unsupported Node.js versions to be
+// able to fail with a friendly error message (see #291). Its static import
+// graph must contain no third-party code except 'semver' (CJS, runs on
+// ancient Node.js). The actual CLI is loaded via dynamic import below.
+import { readFileSync } from 'node:fs'
+import { isSupported } from './utility/node-version.js'
 
-// colored terminal output
-const bb = chalk.blackBright
-const ma = chalk.magenta
-const rb = chalk.redBright
-const yl = chalk.yellow
+const { engines } = JSON.parse(
+  readFileSync(new URL('./package.json', import.meta.url)))
 
-/**
- * if package was linked to global strip relative path from output
- * @param {String} $0 raw value of argv.$0
- * @returns {String} script name with relative path stripped if linked
- */
-function getScriptName ($0) {
-  if ($0.startsWith('.')) {
-    return $0.substring($0.lastIndexOf('/') + 1)
-  }
-  return $0
+if (!isSupported(process.versions.node, engines.node)) {
+  console.error(
+    `Unsupported Node.js version: ${process.version}\n` +
+    `xst requires Node.js ${engines.node}.\n` +
+    'Please install a supported version to run xst, e.g. from https://nodejs.org/')
+  process.exit(1)
 }
-
-function showCompletionHelp (scriptName) {
-  console.log(`
-${bb('Install command completions for ZSH and BASH')}
-  ${scriptName} completion`)
-}
-
-function showExamples (scriptName) {
-  console.log(`
-${bb('Examples:')}
-  ${scriptName} run 'count(//p)'
-  ${scriptName} list --tree --depth 1 /db/apps
-  ${scriptName} package install from-registry demo-apps
-`)
-}
-
-function showLogo () {
-  console.log('\n' +
-    ma`  ╲ ╱  ╓───  ──┰──` + '\n' +
-    rb`   ╳   ╰───╮   │  ` + '\n' +
-    yl`  ╱ ╲  ▂▁▁▁│   ┇  ` + '\n'
-  )
-  console.log(yl`A modern command line interface for exist-db`)
-}
-
-const parser = yargs(hideBin(process.argv))
-  .scriptName('xst')
-  .config('config', 'Read configuration file', configure)
-  .middleware(readConnection)
-  .usageConfiguration({ 'hide-types': true })
-  .completion('completion', false)
-  .strictCommands(true)
-  .strictOptions(false)
-  .help()
-  .command('$0 [<command>]', 'Interact with an eXist-db', () => {}, async (argv) => {
-    if (argv.command) {
-      console.error(`Command "${argv.command}" not recognized.
-Try xst --help`)
-    }
-
-    showLogo()
-    const scriptName = getScriptName(argv.$0)
-    showCompletionHelp(scriptName)
-    // append examples
-    showExamples(scriptName)
-  })
-  .command(commands)
-  // .recommendCommands()
-  .fail(false)
-
-parser.wrap(parser.terminalWidth())
 
 try {
-  await parser.parse()
+  await import('./app.js')
 } catch (error) {
-  handleError(error)
-  parser.getHelp()
-  process.exit(1)
+  // Belt and braces: a SyntaxError raised while loading the import chain
+  // points at an incompatible runtime as well (e.g. exotic setups where
+  // the reported version passes the check above).
+  if (error instanceof SyntaxError) {
+    console.error(
+      `${error.message}\n` +
+      `xst requires Node.js ${engines.node} (you are running ${process.version}).`)
+    process.exit(1)
+  }
+  throw error
 }

--- a/commands/upload.js
+++ b/commands/upload.js
@@ -8,6 +8,7 @@ import { getXmlRpcClient, getMimeType } from '@existdb/node-exist'
 import { logFailure, logSuccess } from '../utility/message.js'
 import { formatErrorMessage, isNetworkError } from '../utility/errors.js'
 import { getServerUrl, getUserInfo } from '../utility/connection.js'
+import { stringList } from '../utility/options.js'
 
 /**
  * @typedef { import("../utility/account.js").AccountInfo } AccountInfo
@@ -22,15 +23,6 @@ import { getServerUrl, getUserInfo } from '../utility/connection.js'
  * @prop {Boolean} exists the collection exists
  * @prop {Boolean} created the collection was created
  */
-
-const stringList = {
-  type: 'string',
-  array: true,
-  coerce: (values) =>
-    values.length === 1 && values[0].trim() === 'false'
-      ? ['**']
-      : values.reduce((values, value) => values.concat(value.split(',').map((value) => value.trim())), [])
-}
 
 /**
  * Upload a single resource into an existdb instance

--- a/readme.md
+++ b/readme.md
@@ -24,11 +24,13 @@ Built on top of [@existdb/node-exist](https://www.npmjs.com/package/@existdb/nod
 
 ## Installation
 
-Prerequisite: [nodeJS](https://nodejs.org/) version 18 or later
+Prerequisite: [Node.js](https://nodejs.org/) 20.19 or later (Node 22.11+ for the 22.x line)
 
 `npm install --global @existdb/xst`
 
 This will put the executable `xst` in your path.
+
+**Troubleshooting:** If `xst` fails right after installation with a `SyntaxError` mentioning a missing export, your Node.js version is too old — check `node --version` against the requirement above.
 
 ### Updating
 

--- a/spec/test.js
+++ b/spec/test.js
@@ -1,8 +1,45 @@
 import { spawn } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
 
 /**
  * @typedef {Promise<{stderr?: string, stdout?: string, code: number}>} CommandResult
  */
+
+// ---------------------------------------------------------------------------
+// Test target resolution
+//
+// The suite always tests the CLI of THIS checkout by spawning
+// `node <checkout>/cli.js` — never a globally installed or npm-linked xst.
+// This makes `npm test` safe in git worktrees: each worktree tests its own
+// code. Set XST_TEST_BIN to test a packaged binary instead (e.g. ./xst-linux).
+// ---------------------------------------------------------------------------
+const cliPath = fileURLToPath(new URL('../cli.js', import.meta.url))
+const testBin = process.env.XST_TEST_BIN
+
+function resolveXst (cmd, args = []) {
+  if (cmd !== 'xst') { return [cmd, args] }
+  if (testBin) { return [testBin, args] }
+  return [process.execPath, [cliPath, ...args]]
+}
+
+// ---------------------------------------------------------------------------
+// Test server resolution
+//
+// Defaults match CI: an eXist-db instance with its HTTPS/HTTP ports published
+// on localhost:8443/8080. To run the suite against an isolated instance (e.g.
+// per-worktree containers on other ports) set
+//
+//   XST_TEST_SERVER=https://localhost:11291 \
+//   XST_TEST_HTTP_SERVER=http://localhost:10291 npm test
+//
+// When XST_TEST_SERVER is set it is injected as EXISTDB_SERVER into every
+// spawned process; suites that specifically test connection *defaults*
+// (spec/tests/configuration.js) skip themselves in that case.
+// ---------------------------------------------------------------------------
+export const isIsolated = Boolean(process.env.XST_TEST_SERVER)
+export const testServer = process.env.XST_TEST_SERVER || 'https://localhost:8443'
+export const testHttpServer = process.env.XST_TEST_HTTP_SERVER || 'http://localhost:8080'
+const serverEnv = isIsolated ? { EXISTDB_SERVER: testServer } : {}
 
 /**
  * Run an shell command
@@ -13,10 +50,11 @@ import { spawn } from 'node:child_process'
  * @returns {CommandResult} The result of running the command
  */
 export async function run (cmd, args, options = cleanEnv) {
+  const [command, commandArgs] = resolveXst(cmd, args)
   return new Promise((resolve, reject) => {
     let stderr
     let stdout
-    const proc = spawn(cmd, args, options)
+    const proc = spawn(command, commandArgs, options)
     proc.stdout.on('data', (data) => {
       stdout ? (stdout += data.toString()) : (stdout = data.toString())
     })
@@ -45,11 +83,13 @@ export async function run (cmd, args, options = cleanEnv) {
  * @returns {CommandResult} The result of the pipe
  */
 export async function runPipe (cmd1, args1, cmd2, args2, options = cleanEnv) {
+  const [command1, commandArgs1] = resolveXst(cmd1, args1)
+  const [command2, commandArgs2] = resolveXst(cmd2, args2)
   return new Promise((resolve, reject) => {
     let stderr
     let stdout
-    const proc1 = spawn(cmd1, args1, options)
-    const proc2 = spawn(cmd2, args2, options)
+    const proc1 = spawn(command1, commandArgs1, options)
+    const proc2 = spawn(command2, commandArgs2, options)
     proc1.stdout.pipe(proc2.stdin)
 
     proc2.stdout.on('data', (data) => {
@@ -68,14 +108,14 @@ export async function runPipe (cmd1, args1, cmd2, args2, options = cleanEnv) {
 // guard test execution against environment variables in development setups
 const { EXISTDB_PASS, EXISTDB_USER, EXISTDB_SERVER, ...filteredEnv } = process.env
 export const cleanEnv = {
-  env: filteredEnv
+  env: { ...filteredEnv, ...serverEnv }
 }
 export const asGuest = {
-  env: { ...filteredEnv, EXISTDB_USER: 'guest', EXISTDB_PASS: 'guest' }
+  env: { ...filteredEnv, ...serverEnv, EXISTDB_USER: 'guest', EXISTDB_PASS: 'guest' }
 }
 export const asAdmin = {
-  env: { ...filteredEnv, EXISTDB_USER: 'admin', EXISTDB_PASS: '' }
+  env: { ...filteredEnv, ...serverEnv, EXISTDB_USER: 'admin', EXISTDB_PASS: '' }
 }
 export function forceColorLevel (level) {
-  return { env: { ...filteredEnv, FORCE_COLOR: level } }
+  return { env: { ...filteredEnv, ...serverEnv, FORCE_COLOR: level } }
 }

--- a/spec/test.js
+++ b/spec/test.js
@@ -41,6 +41,14 @@ export const testServer = process.env.XST_TEST_SERVER || 'https://localhost:8443
 export const testHttpServer = process.env.XST_TEST_HTTP_SERVER || 'http://localhost:8080'
 const serverEnv = isIsolated ? { EXISTDB_SERVER: testServer } : {}
 
+// Some suites (spec/tests/exec.js) run command handlers in-process via the
+// yargs parser instead of spawning the CLI; those read process.env directly.
+// Inject the override into this process too, so in-process tests hit the
+// same isolated instance as spawned ones.
+if (isIsolated) {
+  process.env.EXISTDB_SERVER = testServer
+}
+
 /**
  * Run an shell command
  *

--- a/spec/tests/configuration.js
+++ b/spec/tests/configuration.js
@@ -1,7 +1,13 @@
 import { test } from 'tape'
-import { run, asAdmin, cleanEnv } from '../test.js'
+import { run, asAdmin, cleanEnv, isIsolated } from '../test.js'
 
-test('no config file or env variables defaults to guest user', async function (t) {
+// This suite tests connection *defaults* and fixture config files, all of
+// which pin the default ports (8443/8080). When the suite is pointed at an
+// isolated instance via XST_TEST_SERVER these tests cannot pass and are
+// skipped — they still run in CI and in default local runs.
+const opts = { skip: isIsolated }
+
+test('no config file or env variables defaults to guest user', opts, async function (t) {
   const { stderr, stdout } = await run('xst', ['exec', '-f', 'modules/whoami.xq'])
   if (stderr) {
     return t.fail(stderr)
@@ -13,7 +19,7 @@ test('no config file or env variables defaults to guest user', async function (t
   t.end()
 })
 
-test('read config file', async function (t) {
+test('read config file', opts, async function (t) {
   const { stderr, stdout } = await run('xst', ['exec', '--config', 'spec/fixtures/.xstrc', '-f', 'modules/whoami.xq'])
   if (stderr) {
     return t.fail(stderr)
@@ -25,7 +31,7 @@ test('read config file', async function (t) {
   t.end()
 })
 
-test('reads environment variables', async function (t) {
+test('reads environment variables', opts, async function (t) {
   const { stderr, stdout } = await run('xst', ['exec', '-f', 'modules/whoami.xq'], asAdmin)
   if (stderr) {
     return t.fail(stderr)
@@ -37,7 +43,7 @@ test('reads environment variables', async function (t) {
   t.end()
 })
 
-test('reads configuration from .env', async function (t) {
+test('reads configuration from .env', opts, async function (t) {
   const { stderr, stdout } = await run('xst', ['exec', '--config', 'spec/fixtures/.env', '-f', 'modules/whoami.xq'])
   if (stderr) {
     return t.fail(stderr)
@@ -49,7 +55,7 @@ test('reads configuration from .env', async function (t) {
   t.end()
 })
 
-test('reads configuration from .env.staging', async function (t) {
+test('reads configuration from .env.staging', opts, async function (t) {
   const { stderr, stdout } = await run('xst', ['exec', '--config', 'spec/fixtures/.env.staging', '-f', 'modules/whoami.xq'])
   if (stderr) {
     return t.fail(stderr)
@@ -61,7 +67,7 @@ test('reads configuration from .env.staging', async function (t) {
   t.end()
 })
 
-test('reads connection from .existdb.json', async function (t) {
+test('reads connection from .existdb.json', opts, async function (t) {
   const { stderr, stdout } = await run('xst', ['exec', '--config', 'spec/fixtures/.existdb.json', '-f', 'modules/whoami.xq'])
   if (stderr) {
     return t.fail(stderr)
@@ -73,7 +79,7 @@ test('reads connection from .existdb.json', async function (t) {
   t.end()
 })
 
-test('connection options set in configuration overrides environment variables', async function (t) {
+test('connection options set in configuration overrides environment variables', opts, async function (t) {
   const { stderr, stdout } = await run('xst', ['exec', '--config', 'spec/fixtures/.env', '-f', 'modules/whoami.xq'], asAdmin)
   if (stderr) {
     return t.fail(stderr)
@@ -85,14 +91,14 @@ test('connection options set in configuration overrides environment variables', 
   t.end()
 })
 
-test('fail if config file was not found', async function (t) {
+test('fail if config file was not found', opts, async function (t) {
   const { stderr, stdout } = await run('xst', ['exec', '--config', 'non-existent.file', '-f', 'modules/whoami.xq'], asAdmin)
   if (stdout) return t.fail(stdout)
   t.ok(stderr, stderr)
   t.end()
 })
 
-test('configuration cascade', function (st) {
+test('configuration cascade', opts, function (st) {
   st.test('connection.xstrc fails to connect (certificate expired)', async function (t) {
     const { stderr, stdout } = await run('xst', ['exec', '--config', 'spec/fixtures/connection.xstrc', '-f', 'modules/whoami.xq', '--verbose'])
     const lines = stderr.split('\n')

--- a/spec/tests/exec.js
+++ b/spec/tests/exec.js
@@ -1,12 +1,18 @@
 import { test } from 'tape'
 import yargs from 'yargs'
 import * as exec from '../../commands/exec.js'
+import { readConnection } from '../../utility/connection.js'
 import { runPipe } from '../test.js'
 
-// a yargs instance must not be reused across parses: on a reused instance a
+// Mirror cli.js: resolve connection options from the environment so in-process
+// handlers connect to the same instance as spawned ones (the isolated server
+// under XST_TEST_SERVER, or the CI default otherwise). Without this the handler
+// falls back to node-exist's hardcoded default and, under isolation, floods an
+// uncaught ECONNREFUSED that crashes the suite.
+// A yargs instance must not be reused across parses: on a reused instance a
 // boolean option next to the positional (e.g. `execute --stats 1+1`) silently
-// drops the positional, so each parse gets a fresh parser
-const parser = () => yargs().scriptName('xst').command(exec).help().fail(false)
+// drops the positional, so each parse gets a fresh parser.
+const parser = () => yargs().scriptName('xst').command(exec).middleware(readConnection).help().fail(false)
 
 const execCmd = async (cmd, args) => {
   return await yargs()

--- a/spec/tests/get.js
+++ b/spec/tests/get.js
@@ -182,12 +182,12 @@ test('with test collection', async (t) => {
 
     // files are not downloaded in reproducible order
     st.equal(
-      lines.filter((l) => /^✔︎ created directory [/\w]+\/get-test/.exec(l)).length,
+      lines.filter((l) => /^✔︎ created directory [/.\w-]+\/get-test/.exec(l)).length,
       3,
       'notify 3 directories created'
     )
     st.equal(
-      lines.filter((l) => /^✔︎ downloaded resource [/\w]+\/get-test/.exec(l)).length,
+      lines.filter((l) => /^✔︎ downloaded resource [/.\w-]+\/get-test/.exec(l)).length,
       10,
       'notify 10 resources downloaded'
     )

--- a/spec/tests/get.js
+++ b/spec/tests/get.js
@@ -1,5 +1,5 @@
 import { test } from 'tape'
-import { run, asAdmin } from '../test.js'
+import { run, asAdmin, testServer } from '../test.js'
 import { readdirSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
@@ -172,7 +172,7 @@ test('with test collection', async (t) => {
     const { stderr, stdout } = await run('xst', ['get', '--verbose', testCollection, '.'], asAdmin)
     st.plan(9)
     const verboseLines = stderr.split('\n')
-    st.equal(verboseLines[0], 'Connecting to https://localhost:8443 as admin', verboseLines[0])
+    st.equal(verboseLines[0], `Connecting to ${testServer} as admin`, verboseLines[0])
     st.ok(verboseLines[1].startsWith('Downloading /db/get-test to'), verboseLines[1])
     st.equal(verboseLines[2], 'Downloading up to 4 resources at a time', verboseLines[2])
     st.equal(verboseLines[3], '', verboseLines[3])

--- a/spec/tests/info.js
+++ b/spec/tests/info.js
@@ -1,5 +1,5 @@
 import { test } from 'tape'
-import { run, asAdmin } from '../test.js'
+import { run, asAdmin, testServer } from '../test.js'
 
 test("calling 'xst info'", async (t) => {
   const { stderr, stdout } = await run('xst', ['info'])
@@ -16,7 +16,7 @@ test("calling 'xst info'", async (t) => {
 test("calling 'xst info --verbose'", async (t) => {
   const { stderr, stdout } = await run('xst', ['info', '--verbose'])
   t.plan(5)
-  t.equal(stderr, 'Connecting to https://localhost:8443 as guest\n', 'connection and user output on stderr')
+  t.equal(stderr, `Connecting to ${testServer} as guest\n`, 'connection and user output on stderr')
 
   const lines = stdout.split('\n')
   t.equal(lines.length, 4, 'outputs four lines')

--- a/spec/tests/package/install/registry.js
+++ b/spec/tests/package/install/registry.js
@@ -1,6 +1,8 @@
 import { readFile } from 'node:fs/promises'
 import test from 'tape'
-import { run, asAdmin } from '../../../test.js'
+import { run, asAdmin, testHttpServer } from '../../../test.js'
+
+const publicRepo = `${testHttpServer}/exist/apps/public-repo`
 
 const testAppName = 'http://exist-db.org/apps/test-app'
 const testLibName = 'http://exist-db.org/apps/test-lib'
@@ -33,8 +35,13 @@ async function cleanup (t) {
 }
 
 async function isLocalRepoAvailable () {
-  const { status } = await fetch('http://localhost:8080/exist/apps/public-repo')
-  return status === 200
+  try {
+    const { status } = await fetch(publicRepo)
+    return status === 200
+  } catch (_) {
+    // connection refused — no instance (or no public-repo) on this port
+    return false
+  }
 }
 
 /**
@@ -49,9 +56,8 @@ async function installPackageToLocalRepo (t) {
     formData.append('files[]', blob, app)
     formData.append('', '\\')
 
-    // TODO: Read in localhost
     const { status } = await fetch(
-      'http://localhost:8080/exist/apps/public-repo/publish',
+      `${publicRepo}/publish`,
       {
         method: 'post',
         headers: {
@@ -122,7 +128,7 @@ test('Work with a local public registry', async function (t) {
       'install',
       'registry',
       '--registry',
-      'http://localhost:8080/exist/apps/public-repo',
+      publicRepo,
       testAppName
     ])
     st.equal(
@@ -145,7 +151,7 @@ test('Work with a local public registry', async function (t) {
           'install',
           'registry',
           '--registry',
-          'http://localhost:8080/exist/apps/public-repo',
+          publicRepo,
           testAppName
         ],
         asAdmin
@@ -173,7 +179,7 @@ test('Work with a local public registry', async function (t) {
           'install',
           'registry',
           '--registry',
-          'http://localhost:8080/exist/apps/public-repo',
+          publicRepo,
           'test-app'
         ],
         asAdmin
@@ -222,7 +228,7 @@ test('Work with a local public registry', async function (t) {
           'install',
           'registry',
           '--registry',
-          'http://localhost:8080/exist/apps/public-repo',
+          publicRepo,
           testAppName,
           '1.0.1'
         ],
@@ -248,7 +254,7 @@ test('Work with a local public registry', async function (t) {
         'install',
         'registry',
         '--registry',
-        'http://localhost:8080/exist/apps/public-repo',
+        publicRepo,
         testAppName,
         '1.0.1',
         '--force'
@@ -279,7 +285,7 @@ test('Work with a local public registry', async function (t) {
           'install',
           'registry',
           '--registry',
-          'http://localhost:8080/exist/apps/public-repo',
+          publicRepo,
           testAppName,
           '10.98.2'
         ],
@@ -308,7 +314,7 @@ test('Work with a local public registry', async function (t) {
           'install',
           'registry',
           '--registry',
-          'http://localhost:8080/doesnotexist/',
+          `${testHttpServer}/doesnotexist/`,
           testAppName
         ],
         asAdmin
@@ -319,7 +325,7 @@ test('Work with a local public registry', async function (t) {
       // @todo: maybe a better error here? Explain user what actually went wrong?
       st.equal(
         stderr,
-        '✘ http://exist-db.org/apps/test-app > Server responded with a Servlet error. Probably a wrong path to the public-repo or public-repo not installed. Please check the URL http://localhost:8080/doesnotexist/\n',
+        `✘ http://exist-db.org/apps/test-app > Server responded with a Servlet error. Probably a wrong path to the public-repo or public-repo not installed. Please check the URL ${testHttpServer}/doesnotexist/\n`,
         stderr
       )
       st.end()

--- a/spec/tests/package/list.js
+++ b/spec/tests/package/list.js
@@ -1,5 +1,5 @@
 import { test } from 'tape'
-import { run, asAdmin } from '../../test.js'
+import { run, asAdmin, testServer } from '../../test.js'
 
 const testAppName = 'http://exist-db.org/apps/test-app'
 const testLibName = 'http://exist-db.org/apps/test-lib'
@@ -86,7 +86,7 @@ test.skip('sorts by type and installation date', async function (t) {
 
   if (stderr) { return t.fail(stderr) }
   const lines = stdout.split('\n')
-  t.equal(lines[0], 'Install test-app.xar on https://localhost:8443')
+  t.equal(lines[0], `Install test-app.xar on ${testServer}`)
 })
 
 test('with new package', async function (t) {

--- a/spec/tests/upload.js
+++ b/spec/tests/upload.js
@@ -1,5 +1,5 @@
 import { test } from 'tape'
-import { run, asAdmin } from '../test.js'
+import { run, asAdmin, testServer } from '../test.js'
 
 const testCollection = '/db/upload-test'
 
@@ -41,7 +41,7 @@ test('uploading files and folders', function (t) {
     const { stderr, stdout, code } = await run('xst', ['up', '-v', 'spec/test.js', testCollection])
     st.equal(code, 1, 'exit code 1')
     const lines = stderr.split('\n')
-    st.equal(lines[0], 'Connecting to https://localhost:8443 as guest', lines[0])
+    st.equal(lines[0], `Connecting to ${testServer} as guest`, lines[0])
     st.equal(lines[1], '✘ test.js Error: Write permission is not granted on the Collection.', lines[1])
     st.ok(/Upload of .+?spec\/test\.js failed\./.test(lines[2]), lines[2])
     st.ok(stdout, 'additional info is displayed')
@@ -72,7 +72,7 @@ test('uploading files and folders', function (t) {
     const { stderr, stdout, code } = await run('xst', ['up', '-v', 'spec/fixtures/test.xq', testCollection])
     st.equal(code, 1, 'exit code 1')
     const lines = stderr.split('\n')
-    st.equal(lines[0], 'Connecting to https://localhost:8443 as guest', lines[0])
+    st.equal(lines[0], `Connecting to ${testServer} as guest`, lines[0])
     st.equal(lines[1], '✘ test.xq Error: A resource with the same name already exists in the target collection \'/db/upload-test\', and you do not have write access on that resource.')
     st.ok(/Upload of .+?spec\/fixtures\/test\.xq failed\./.test(lines[2]))
     st.ok(stdout, 'additional info is displayed')

--- a/spec/tests/utility/db-path.js
+++ b/spec/tests/utility/db-path.js
@@ -1,0 +1,54 @@
+import { test } from 'tape'
+import { assertAbsoluteDbPath, normalizeDbPath } from '../../../utility/db-path.js'
+
+test('assertAbsoluteDbPath', function (t) {
+  t.test('accepts absolute paths', function (st) {
+    st.equals(assertAbsoluteDbPath('/db'), '/db')
+    st.equals(assertAbsoluteDbPath('/'), '/')
+    st.equals(assertAbsoluteDbPath('/db/apps/'), '/db/apps/')
+    st.end()
+  })
+
+  t.test('rejects relative paths with a hint', function (st) {
+    st.throws(
+      () => assertAbsoluteDbPath('my/collection'),
+      /Did you mean "\/db\/my\/collection"\?/,
+      'plain relative path hints /db prefix')
+    st.throws(
+      () => assertAbsoluteDbPath('db/apps'),
+      /Did you mean "\/db\/apps"\?/,
+      'path starting with db/ hints leading slash only')
+    st.throws(
+      () => assertAbsoluteDbPath('db'),
+      /Did you mean "\/db"\?/,
+      'bare db hints /db')
+    st.end()
+  })
+
+  t.test('rejects empty and non-string values', function (st) {
+    st.throws(() => assertAbsoluteDbPath(''), /non-empty/)
+    st.throws(() => assertAbsoluteDbPath(undefined), /non-empty/)
+    st.throws(() => assertAbsoluteDbPath(null), /non-empty/)
+    st.end()
+  })
+})
+
+test('normalizeDbPath', function (t) {
+  t.test('resolves / to /db', function (st) {
+    st.equals(normalizeDbPath('/'), '/db')
+    st.end()
+  })
+
+  t.test('strips trailing slashes', function (st) {
+    st.equals(normalizeDbPath('/db/'), '/db')
+    st.equals(normalizeDbPath('/db/apps///'), '/db/apps')
+    st.equals(normalizeDbPath('//'), '/db')
+    st.end()
+  })
+
+  t.test('leaves canonical paths untouched', function (st) {
+    st.equals(normalizeDbPath('/db'), '/db')
+    st.equals(normalizeDbPath('/db/apps'), '/db/apps')
+    st.end()
+  })
+})

--- a/spec/tests/utility/node-version.js
+++ b/spec/tests/utility/node-version.js
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs'
+import { test } from 'tape'
+import { isSupported } from '../../../utility/node-version.js'
+
+// test against the actual supported range (single source of truth)
+const { engines } = JSON.parse(
+  readFileSync(new URL('../../../package.json', import.meta.url)))
+
+test('isSupported with the engines.node range from package.json', function (t) {
+  t.test('rejects Node.js versions below 20.19.0', function (st) {
+    st.notOk(isSupported('18.19.0', engines.node), '18.19.0 is not supported')
+    st.notOk(isSupported('20.18.0', engines.node), '20.18.0 is not supported')
+    st.end()
+  })
+
+  t.test('accepts the 20.x line from 20.19.0 on', function (st) {
+    st.ok(isSupported('20.19.0', engines.node), '20.19.0 is supported')
+    st.ok(isSupported('20.20.0', engines.node), '20.20.0 is supported')
+    st.end()
+  })
+
+  t.test('rejects 21.x and 22.x below 22.11.0', function (st) {
+    st.notOk(isSupported('21.0.0', engines.node), '21.0.0 is not supported')
+    st.notOk(isSupported('22.10.0', engines.node), '22.10.0 is not supported')
+    st.end()
+  })
+
+  t.test('accepts 22.11.0 and later', function (st) {
+    st.ok(isSupported('22.11.0', engines.node), '22.11.0 is supported')
+    st.ok(isSupported('24.0.0', engines.node), '24.0.0 is supported')
+    st.end()
+  })
+})

--- a/utility/db-path.js
+++ b/utility/db-path.js
@@ -1,0 +1,45 @@
+/**
+ * Shared handling of database collection and resource paths.
+ *
+ * Semantics:
+ * - database paths must be absolute (leading slash)
+ * - "/" is an alias for "/db", the root collection
+ * - trailing slashes are ignored
+ */
+
+/**
+ * Ensure a database path is absolute.
+ * Throws with a helpful hint otherwise.
+ * @param {String} path database path
+ * @returns {String} the path, unchanged
+ */
+export function assertAbsoluteDbPath (path) {
+  if (typeof path !== 'string' || path === '') {
+    throw Error('Invalid path: database paths must be non-empty strings.')
+  }
+  if (!path.startsWith('/')) {
+    const hint = path === 'db' || path.startsWith('db/')
+      ? '/' + path
+      : '/db/' + path
+    throw Error(
+      `Invalid path "${path}": database paths must be absolute. Did you mean "${hint}"?`)
+  }
+  return path
+}
+
+/**
+ * Canonicalize an absolute database path.
+ * Strips trailing slashes, resolves "/" to "/db".
+ * @param {String} path absolute database path
+ * @returns {String} normalized path
+ */
+export function normalizeDbPath (path) {
+  let normalized = path
+  while (normalized.length > 1 && normalized.endsWith('/')) {
+    normalized = normalized.substring(0, normalized.length - 1)
+  }
+  if (normalized === '/') {
+    return '/db'
+  }
+  return normalized
+}

--- a/utility/node-version.js
+++ b/utility/node-version.js
@@ -1,0 +1,15 @@
+import { satisfies } from 'semver'
+
+/**
+ * Check if a Node.js version satisfies a semver range.
+ * Used by the launcher (cli.js) to guard against unsupported
+ * Node.js versions before any third-party code is imported.
+ * Only 'semver' may be imported here — it is CJS and parses on
+ * ancient Node.js versions.
+ * @param {String} version Node.js version (e.g. process.versions.node)
+ * @param {String} range semver range (e.g. engines.node from package.json)
+ * @returns {Boolean} true if the version satisfies the range
+ */
+export function isSupported (version, range) {
+  return satisfies(version, range)
+}

--- a/utility/options.js
+++ b/utility/options.js
@@ -1,0 +1,17 @@
+/**
+ * shared yargs option helpers
+ */
+
+/**
+ * Option definition mixin for repeatable, comma-separated string list
+ * options (e.g. --include, --exclude).
+ * The single value "false" yields the match-all pattern ['**'].
+ */
+export const stringList = {
+  type: 'string',
+  array: true,
+  coerce: (values) =>
+    values.length === 1 && values[0].trim() === 'false'
+      ? ['**']
+      : values.reduce((values, value) => values.concat(value.split(',').map((value) => value.trim())), [])
+}


### PR DESCRIPTION
## Summary
- On Node.js older than the `engines` range, `xst` crashed deep inside the import chain of its dependencies (a `SyntaxError` from execa) with no hint at the cause. `cli.js` is now a thin launcher whose static imports are only `node:` built-ins and `semver` (CJS, parses on ancient Node). It checks `process.versions.node` against the range read from `package.json`, prints a friendly error to stderr and exits 1; only then is the actual CLI (`app.js`, the former `cli.js`) loaded via dynamic `import()`. The range check lives in `utility/node-version.js` with unit tests.
- Readme states the actual requirement (`^20.19.0 || >=22.11.0` instead of "18 or later") and adds a short troubleshooting note for the `SyntaxError` seen on too-old Node.js.
- CLI usage output always presents `xst` as the program name, regardless of how it was launched.

Closes #291
Closes #292

The first seven commits are the shared test-infra base (suite worktree-safe and server-configurable, `db-path`/`stringList` helpers) also carried by #382 and #391; they drop out of this PR once either lands.

## Test plan
- [x] `npm test` (standard + full tape suite, 403/403) against an isolated `existdb/existdb:release` instance on Node 24.10.0
- [x] `spec/tests/utility/node-version.js` covers 18.19.0 / 20.18.0 / 20.19.0 / 21.x / 22.11.0 boundaries
- [ ] Manual: run `node cli.js --version` under Node 18 and confirm the friendly error instead of the execa `SyntaxError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DdRCqwxEhrKX2uQDL1Ahsy