### PR TITLE
feat: add --stats option to execute command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ node_modules
 # artifacts
 *.tgz
 coverage
+
+# implementation plans (local only)
+plans/

--- a/cli.js
+++ b/cli.js
@@ -51,6 +51,7 @@ function showLogo () {
 }
 
 const parser = yargs(hideBin(process.argv))
+  .scriptName('xst')
   .config('config', 'Read configuration file', configure)
   .middleware(readConnection)
   .usageConfiguration({ 'hide-types': true })

--- a/commands/exec.js
+++ b/commands/exec.js
@@ -1,5 +1,11 @@
 import { getXmlRpcClient } from '@existdb/node-exist'
 import { readFileSync } from 'node:fs'
+import { readXquery } from '../utility/xq.js'
+
+/**
+ * the timing harness executed on the DB when the stats option is set
+ */
+const statsQuery = readXquery('exec-stats.xq')
 
 /**
  * parse bindings
@@ -76,6 +82,34 @@ async function execute (db, query, variables) {
   return 0
 }
 
+/**
+ * query db wrapped in a timing harness,
+ * output result to standard out and timings to standard error
+ *
+ * The harness returns the measured times as its first result item;
+ * all following items are the results of the wrapped query and reach
+ * standard out through the exact same code path as without stats.
+ *
+ * @param {NodeExist.BoundModules} db bound NodeExist modules
+ * @param {string|Buffer} query the query to execute
+ * @param {object} [variables] the bound variables
+ * @returns {Promise<Number>} exit code
+ */
+async function executeWithStats (db, query, variables = {}) {
+  if (Object.hasOwn(variables, 'query')) {
+    throw Error('Cannot bind variable "query" when the stats option is set')
+  }
+  const result = await db.queries.readAll(statsQuery, {
+    variables: { ...variables, query: query.toString() }
+  })
+  const [stats, ...pages] = result.pages
+  const { compilation, execution } = JSON.parse(stats.toString())
+  console.log(pages.toString())
+  console.error(`compilation: ${compilation}ms`)
+  console.error(`execution:   ${execution}ms`)
+  return 0
+}
+
 export const command = ['execute [<query>] [options]', 'run', 'exec']
 export const describe = 'Execute a query string or file'
 
@@ -94,6 +128,12 @@ export async function builder (yargs) {
       coerce: parseBindings,
       default: () => {}
     })
+    .option('s', {
+      alias: 'stats',
+      type: 'boolean',
+      default: false,
+      describe: 'Print compilation and execution time of the query to standard error'
+    })
     .option('h', { alias: 'help', type: 'boolean' })
     .nargs({ f: 1, b: 1 })
     .conflicts('f', 'query')
@@ -104,9 +144,12 @@ export async function handler (argv) {
   if (argv.help) {
     return 0
   }
-  const { file, bind, query } = argv
+  const { file, bind, query, stats } = argv
   const _query = getQuery(file, query)
   const db = getXmlRpcClient(argv.connectionOptions)
 
+  if (stats) {
+    return await executeWithStats(db, _query, bind)
+  }
   return await execute(db, _query, bind)
 }

--- a/commands/upload.js
+++ b/commands/upload.js
@@ -8,6 +8,7 @@ import { getXmlRpcClient, getMimeType } from '@existdb/node-exist'
 import { logFailure, logSuccess } from '../utility/message.js'
 import { formatErrorMessage, isNetworkError } from '../utility/errors.js'
 import { getServerUrl, getUserInfo } from '../utility/connection.js'
+import { stringList } from '../utility/options.js'
 
 /**
  * @typedef { import("../utility/account.js").AccountInfo } AccountInfo
@@ -22,15 +23,6 @@ import { getServerUrl, getUserInfo } from '../utility/connection.js'
  * @prop {Boolean} exists the collection exists
  * @prop {Boolean} created the collection was created
  */
-
-const stringList = {
-  type: 'string',
-  array: true,
-  coerce: (values) =>
-    values.length === 1 && values[0].trim() === 'false'
-      ? ['**']
-      : values.reduce((values, value) => values.concat(value.split(',').map((value) => value.trim())), [])
-}
 
 /**
  * Upload a single resource into an existdb instance

--- a/modules/exec-stats.xq
+++ b/modules/exec-stats.xq
@@ -1,0 +1,49 @@
+xquery version "3.1";
+
+(:~
+ : Timing harness for `xst execute --stats`.
+ :
+ : Compiles and evaluates the query passed in $query, timing both steps
+ : on the server, so network transport is never part of the reported numbers.
+ :
+ : The first item of the returned sequence is a JSON object with the measured
+ : times in milliseconds. All following items are the results of the evaluated
+ : query, untouched, so that the client retrieves and serializes them exactly
+ : as it would without the stats option.
+ :
+ : Variable bindings sent by the client are declared in this query's context
+ : by eXist-db and are visible from within util:eval, because the evaluated
+ : expression inherits the current execution context (including its typed
+ : variable declarations and the statically known documents).
+ :
+ : Measurement semantics:
+ : - "compilation" is an isolated parse and analyze pass (util:compile-query).
+ :   Its outcome is reported as "compile-check" but intentionally not acted
+ :   upon; a query that cannot be compiled will raise the original error from
+ :   util:eval below. A failed check can also be a false negative, because
+ :   util:compile-query does not see the client's variable bindings.
+ : - "execution" is the time util:eval takes. This includes an internal
+ :   recompilation of the query - eXist-db offers no way to evaluate an
+ :   already compiled query separately.
+ : - $pass is set to true() so failing queries keep their original error
+ :   location.
+ :)
+
+declare variable $query as xs:string external;
+
+let $start := util:system-dateTime()
+let $compile-check := util:compile-query($query, ())
+let $compiled := util:system-dateTime()
+let $result := util:eval($query, false(), (), true())
+let $executed := util:system-dateTime()
+return (
+    serialize(
+        map {
+            "compilation": ($compiled - $start) div xs:dayTimeDuration("PT0.001S"),
+            "execution": ($executed - $compiled) div xs:dayTimeDuration("PT0.001S"),
+            "compile-check": string($compile-check/@result)
+        },
+        map { "method": "json" }
+    ),
+    $result
+)

--- a/readme.md
+++ b/readme.md
@@ -148,6 +148,29 @@ you can save it to a file and use the `--file` parameter.
 xst execute --file my-query.xq
 ```
 
+#### Measure query performance
+
+With `--stats` the times the server took to compile and to execute the query
+are reported in addition to the query result.
+
+```bash
+xst execute --stats 'count(//p)'
+```
+
+```
+12345
+compilation: 12ms
+execution:   340ms
+```
+
+Both timings are measured on the server, network transport is not part of the
+reported numbers. The statistics are printed to standard error while the query
+result is still printed to standard output, so piped output remains clean.
+
+```bash
+xst execute --stats 'count(//p)' > result.txt
+```
+
 #### Installation of XAR packages
 
 NOTE: The user initiating the command must be a member of the DBA group.

--- a/spec/test.js
+++ b/spec/test.js
@@ -1,8 +1,45 @@
 import { spawn } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
 
 /**
  * @typedef {Promise<{stderr?: string, stdout?: string, code: number}>} CommandResult
  */
+
+// ---------------------------------------------------------------------------
+// Test target resolution
+//
+// The suite always tests the CLI of THIS checkout by spawning
+// `node <checkout>/cli.js` — never a globally installed or npm-linked xst.
+// This makes `npm test` safe in git worktrees: each worktree tests its own
+// code. Set XST_TEST_BIN to test a packaged binary instead (e.g. ./xst-linux).
+// ---------------------------------------------------------------------------
+const cliPath = fileURLToPath(new URL('../cli.js', import.meta.url))
+const testBin = process.env.XST_TEST_BIN
+
+function resolveXst (cmd, args = []) {
+  if (cmd !== 'xst') { return [cmd, args] }
+  if (testBin) { return [testBin, args] }
+  return [process.execPath, [cliPath, ...args]]
+}
+
+// ---------------------------------------------------------------------------
+// Test server resolution
+//
+// Defaults match CI: an eXist-db instance with its HTTPS/HTTP ports published
+// on localhost:8443/8080. To run the suite against an isolated instance (e.g.
+// per-worktree containers on other ports) set
+//
+//   XST_TEST_SERVER=https://localhost:11291 \
+//   XST_TEST_HTTP_SERVER=http://localhost:10291 npm test
+//
+// When XST_TEST_SERVER is set it is injected as EXISTDB_SERVER into every
+// spawned process; suites that specifically test connection *defaults*
+// (spec/tests/configuration.js) skip themselves in that case.
+// ---------------------------------------------------------------------------
+export const isIsolated = Boolean(process.env.XST_TEST_SERVER)
+export const testServer = process.env.XST_TEST_SERVER || 'https://localhost:8443'
+export const testHttpServer = process.env.XST_TEST_HTTP_SERVER || 'http://localhost:8080'
+const serverEnv = isIsolated ? { EXISTDB_SERVER: testServer } : {}
 
 /**
  * Run an shell command
@@ -13,10 +50,11 @@ import { spawn } from 'node:child_process'
  * @returns {CommandResult} The result of running the command
  */
 export async function run (cmd, args, options = cleanEnv) {
+  const [command, commandArgs] = resolveXst(cmd, args)
   return new Promise((resolve, reject) => {
     let stderr
     let stdout
-    const proc = spawn(cmd, args, options)
+    const proc = spawn(command, commandArgs, options)
     proc.stdout.on('data', (data) => {
       stdout ? (stdout += data.toString()) : (stdout = data.toString())
     })
@@ -45,11 +83,13 @@ export async function run (cmd, args, options = cleanEnv) {
  * @returns {CommandResult} The result of the pipe
  */
 export async function runPipe (cmd1, args1, cmd2, args2, options = cleanEnv) {
+  const [command1, commandArgs1] = resolveXst(cmd1, args1)
+  const [command2, commandArgs2] = resolveXst(cmd2, args2)
   return new Promise((resolve, reject) => {
     let stderr
     let stdout
-    const proc1 = spawn(cmd1, args1, options)
-    const proc2 = spawn(cmd2, args2, options)
+    const proc1 = spawn(command1, commandArgs1, options)
+    const proc2 = spawn(command2, commandArgs2, options)
     proc1.stdout.pipe(proc2.stdin)
 
     proc2.stdout.on('data', (data) => {
@@ -68,14 +108,14 @@ export async function runPipe (cmd1, args1, cmd2, args2, options = cleanEnv) {
 // guard test execution against environment variables in development setups
 const { EXISTDB_PASS, EXISTDB_USER, EXISTDB_SERVER, ...filteredEnv } = process.env
 export const cleanEnv = {
-  env: filteredEnv
+  env: { ...filteredEnv, ...serverEnv }
 }
 export const asGuest = {
-  env: { ...filteredEnv, EXISTDB_USER: 'guest', EXISTDB_PASS: 'guest' }
+  env: { ...filteredEnv, ...serverEnv, EXISTDB_USER: 'guest', EXISTDB_PASS: 'guest' }
 }
 export const asAdmin = {
-  env: { ...filteredEnv, EXISTDB_USER: 'admin', EXISTDB_PASS: '' }
+  env: { ...filteredEnv, ...serverEnv, EXISTDB_USER: 'admin', EXISTDB_PASS: '' }
 }
 export function forceColorLevel (level) {
-  return { env: { ...filteredEnv, FORCE_COLOR: level } }
+  return { env: { ...filteredEnv, ...serverEnv, FORCE_COLOR: level } }
 }

--- a/spec/test.js
+++ b/spec/test.js
@@ -41,6 +41,14 @@ export const testServer = process.env.XST_TEST_SERVER || 'https://localhost:8443
 export const testHttpServer = process.env.XST_TEST_HTTP_SERVER || 'http://localhost:8080'
 const serverEnv = isIsolated ? { EXISTDB_SERVER: testServer } : {}
 
+// Some suites (spec/tests/exec.js) run command handlers in-process via the
+// yargs parser instead of spawning the CLI; those read process.env directly.
+// Inject the override into this process too, so in-process tests hit the
+// same isolated instance as spawned ones.
+if (isIsolated) {
+  process.env.EXISTDB_SERVER = testServer
+}
+
 /**
  * Run an shell command
  *

--- a/spec/tests/configuration.js
+++ b/spec/tests/configuration.js
@@ -1,7 +1,13 @@
 import { test } from 'tape'
-import { run, asAdmin, cleanEnv } from '../test.js'
+import { run, asAdmin, cleanEnv, isIsolated } from '../test.js'
 
-test('no config file or env variables defaults to guest user', async function (t) {
+// This suite tests connection *defaults* and fixture config files, all of
+// which pin the default ports (8443/8080). When the suite is pointed at an
+// isolated instance via XST_TEST_SERVER these tests cannot pass and are
+// skipped — they still run in CI and in default local runs.
+const opts = { skip: isIsolated }
+
+test('no config file or env variables defaults to guest user', opts, async function (t) {
   const { stderr, stdout } = await run('xst', ['exec', '-f', 'modules/whoami.xq'])
   if (stderr) {
     return t.fail(stderr)
@@ -13,7 +19,7 @@ test('no config file or env variables defaults to guest user', async function (t
   t.end()
 })
 
-test('read config file', async function (t) {
+test('read config file', opts, async function (t) {
   const { stderr, stdout } = await run('xst', ['exec', '--config', 'spec/fixtures/.xstrc', '-f', 'modules/whoami.xq'])
   if (stderr) {
     return t.fail(stderr)
@@ -25,7 +31,7 @@ test('read config file', async function (t) {
   t.end()
 })
 
-test('reads environment variables', async function (t) {
+test('reads environment variables', opts, async function (t) {
   const { stderr, stdout } = await run('xst', ['exec', '-f', 'modules/whoami.xq'], asAdmin)
   if (stderr) {
     return t.fail(stderr)
@@ -37,7 +43,7 @@ test('reads environment variables', async function (t) {
   t.end()
 })
 
-test('reads configuration from .env', async function (t) {
+test('reads configuration from .env', opts, async function (t) {
   const { stderr, stdout } = await run('xst', ['exec', '--config', 'spec/fixtures/.env', '-f', 'modules/whoami.xq'])
   if (stderr) {
     return t.fail(stderr)
@@ -49,7 +55,7 @@ test('reads configuration from .env', async function (t) {
   t.end()
 })
 
-test('reads configuration from .env.staging', async function (t) {
+test('reads configuration from .env.staging', opts, async function (t) {
   const { stderr, stdout } = await run('xst', ['exec', '--config', 'spec/fixtures/.env.staging', '-f', 'modules/whoami.xq'])
   if (stderr) {
     return t.fail(stderr)
@@ -61,7 +67,7 @@ test('reads configuration from .env.staging', async function (t) {
   t.end()
 })
 
-test('reads connection from .existdb.json', async function (t) {
+test('reads connection from .existdb.json', opts, async function (t) {
   const { stderr, stdout } = await run('xst', ['exec', '--config', 'spec/fixtures/.existdb.json', '-f', 'modules/whoami.xq'])
   if (stderr) {
     return t.fail(stderr)
@@ -73,7 +79,7 @@ test('reads connection from .existdb.json', async function (t) {
   t.end()
 })
 
-test('connection options set in configuration overrides environment variables', async function (t) {
+test('connection options set in configuration overrides environment variables', opts, async function (t) {
   const { stderr, stdout } = await run('xst', ['exec', '--config', 'spec/fixtures/.env', '-f', 'modules/whoami.xq'], asAdmin)
   if (stderr) {
     return t.fail(stderr)
@@ -85,14 +91,14 @@ test('connection options set in configuration overrides environment variables', 
   t.end()
 })
 
-test('fail if config file was not found', async function (t) {
+test('fail if config file was not found', opts, async function (t) {
   const { stderr, stdout } = await run('xst', ['exec', '--config', 'non-existent.file', '-f', 'modules/whoami.xq'], asAdmin)
   if (stdout) return t.fail(stdout)
   t.ok(stderr, stderr)
   t.end()
 })
 
-test('configuration cascade', function (st) {
+test('configuration cascade', opts, function (st) {
   st.test('connection.xstrc fails to connect (certificate expired)', async function (t) {
     const { stderr, stdout } = await run('xst', ['exec', '--config', 'spec/fixtures/connection.xstrc', '-f', 'modules/whoami.xq', '--verbose'])
     const lines = stderr.split('\n')

--- a/spec/tests/exec.js
+++ b/spec/tests/exec.js
@@ -1,12 +1,18 @@
 import { test } from 'tape'
 import yargs from 'yargs'
 import * as exec from '../../commands/exec.js'
+import { readConnection } from '../../utility/connection.js'
 import { runPipe } from '../test.js'
 
-// a yargs instance must not be reused across parses: on a reused instance a
+// Mirror cli.js: resolve connection options from the environment so in-process
+// handlers connect to the same instance as spawned ones (the isolated server
+// under XST_TEST_SERVER, or the CI default otherwise). Without this the handler
+// falls back to node-exist's hardcoded default and, under isolation, floods an
+// uncaught ECONNREFUSED that crashes the suite.
+// A yargs instance must not be reused across parses: on a reused instance a
 // boolean option next to the positional (e.g. `execute --stats 1+1`) silently
-// drops the positional, so each parse gets a fresh parser
-const parser = () => yargs().scriptName('xst').command(exec).help().fail(false)
+// drops the positional, so each parse gets a fresh parser.
+const parser = () => yargs().scriptName('xst').command(exec).middleware(readConnection).help().fail(false)
 
 const execCmd = async (cmd, args) => {
   return await yargs()

--- a/spec/tests/exec.js
+++ b/spec/tests/exec.js
@@ -9,9 +9,11 @@ import { run, runPipe } from '../test.js'
 // under XST_TEST_SERVER, or the CI default otherwise). Without this the handler
 // falls back to node-exist's hardcoded default and, under isolation, floods an
 // uncaught ECONNREFUSED that crashes the suite.
-// A yargs instance must not be reused across parses: on a reused instance a
-// boolean option next to the positional (e.g. `execute --stats 1+1`) silently
-// drops the positional, so each parse gets a fresh parser.
+//
+// A yargs instance must not be reused across parse() calls: on a reused
+// instance a boolean option alongside the positional (execute --stats 1+1)
+// drops the positional, so the handler sees no query. cli.js builds one parser
+// per process, so this only ever bit the tests. Build a fresh one per parse.
 const parser = () => yargs().scriptName('xst').command(exec).middleware(readConnection).help().fail(false)
 
 const execCmd = async (cmd, args) => {
@@ -150,7 +152,7 @@ test('read query from stdin', async function (t) {
 
 test('parses stats option', async function (t) {
   const argv = await new Promise((resolve, reject) => {
-    parser.parse(['execute', '--stats', '1+1'], (err, argv, output) => {
+    parser().parse(['execute', '--stats', '1+1'], (err, argv, output) => {
       if (err) { return reject(err) }
       resolve(argv)
     })

--- a/spec/tests/exec.js
+++ b/spec/tests/exec.js
@@ -2,7 +2,7 @@ import { test } from 'tape'
 import yargs from 'yargs'
 import * as exec from '../../commands/exec.js'
 import { readConnection } from '../../utility/connection.js'
-import { runPipe } from '../test.js'
+import { run, runPipe } from '../test.js'
 
 // Mirror cli.js: resolve connection options from the environment so in-process
 // handlers connect to the same instance as spawned ones (the isolated server
@@ -146,4 +146,72 @@ test('read query from stdin', async function (t) {
   const { stdout, stderr } = await runPipe('echo', ['1+1'], 'xst', ['exec', '-'])
   if (stderr) { return t.fail(stderr) }
   t.equals('2\n', stdout)
+})
+
+test('parses stats option', async function (t) {
+  const argv = await new Promise((resolve, reject) => {
+    parser.parse(['execute', '--stats', '1+1'], (err, argv, output) => {
+      if (err) { return reject(err) }
+      resolve(argv)
+    })
+  })
+  t.plan(2)
+  t.equal(argv.query, '1+1')
+  t.equal(argv.stats, true)
+})
+
+test('with stats option timings are reported on standard error', async function (t) {
+  const { stdout, stderr, code } = await run('xst', ['execute', '--stats', '1+1'])
+  t.plan(4)
+  t.equal(code, 0)
+  t.equal(stdout, '2\n', 'result is on standard out')
+  t.match(stderr, /compilation: \d+(\.\d+)?ms/, 'compilation time is on standard error')
+  t.match(stderr, /execution: +\d+(\.\d+)?ms/, 'execution time is on standard error')
+})
+
+test('without stats option nothing is written to standard error', async function (t) {
+  const { stdout, stderr } = await run('xst', ['execute', '1+1'])
+  t.plan(2)
+  t.notOk(stderr, 'standard error is empty')
+  t.equal(stdout, '2\n')
+})
+
+test('standard out is identical with and without stats option', async function (t) {
+  // a sequence of several items and an XML node exercise
+  // the result serialization and page join
+  const query = '(1 to 3, <node attribute="value">text</node>)'
+  const withoutStats = await run('xst', ['execute', query])
+  const withStats = await run('xst', ['execute', '--stats', query])
+  if (withoutStats.stderr) { return t.fail(withoutStats.stderr) }
+  t.plan(2)
+  t.ok(withoutStats.stdout, 'query returned a result')
+  t.equal(withStats.stdout, withoutStats.stdout, 'results are identical')
+})
+
+test('stats option works with variable bindings', async function (t) {
+  const { stdout, stderr } = await run('xst', ['execute', '--stats', '-b', '{"a":1}', '$a+$a'])
+  t.plan(2)
+  t.equal(stdout, '2\n', 'bound variable is resolved')
+  t.match(stderr, /execution: +\d+(\.\d+)?ms/, 'execution time is on standard error')
+})
+
+test('with stats option an invalid query reports the original compile error', async function (t) {
+  const invalidQuery = '1+'
+  const withoutStats = await run('xst', ['execute', invalidQuery])
+  const withStats = await run('xst', ['execute', '--stats', invalidQuery])
+  t.plan(5)
+  t.notOk(withStats.stdout, 'no result on standard output')
+  t.ok(withoutStats.code > 0 && withStats.code > 0, 'both runs exit with an error')
+  t.match(withStats.stderr, /XPathException/, 'reports an XPathException')
+  // the original parser error must surface, not a harness error
+  t.match(withStats.stderr, /unexpected token|expecting|XPST0003/i, 'reports the compile error: ' + withStats.stderr)
+  t.doesNotMatch(withStats.stderr, /compilation: \d/, 'no timings are reported for a failing query')
+})
+
+test('binding a variable named query conflicts with the stats option', async function (t) {
+  const { stdout, stderr, code } = await run('xst', ['execute', '--stats', '-b', '{"query":1}', '$query'])
+  t.plan(3)
+  t.notOk(stdout, 'no result on standard output')
+  t.ok(code > 0, 'exits with an error')
+  t.match(stderr, /Cannot bind variable "query"/, 'reports the conflict')
 })

--- a/spec/tests/get.js
+++ b/spec/tests/get.js
@@ -182,12 +182,12 @@ test('with test collection', async (t) => {
 
     // files are not downloaded in reproducible order
     st.equal(
-      lines.filter((l) => /^✔︎ created directory [/\w]+\/get-test/.exec(l)).length,
+      lines.filter((l) => /^✔︎ created directory [/.\w-]+\/get-test/.exec(l)).length,
       3,
       'notify 3 directories created'
     )
     st.equal(
-      lines.filter((l) => /^✔︎ downloaded resource [/\w]+\/get-test/.exec(l)).length,
+      lines.filter((l) => /^✔︎ downloaded resource [/.\w-]+\/get-test/.exec(l)).length,
       10,
       'notify 10 resources downloaded'
     )

--- a/spec/tests/get.js
+++ b/spec/tests/get.js
@@ -1,5 +1,5 @@
 import { test } from 'tape'
-import { run, asAdmin } from '../test.js'
+import { run, asAdmin, testServer } from '../test.js'
 import { readdirSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
@@ -172,7 +172,7 @@ test('with test collection', async (t) => {
     const { stderr, stdout } = await run('xst', ['get', '--verbose', testCollection, '.'], asAdmin)
     st.plan(9)
     const verboseLines = stderr.split('\n')
-    st.equal(verboseLines[0], 'Connecting to https://localhost:8443 as admin', verboseLines[0])
+    st.equal(verboseLines[0], `Connecting to ${testServer} as admin`, verboseLines[0])
     st.ok(verboseLines[1].startsWith('Downloading /db/get-test to'), verboseLines[1])
     st.equal(verboseLines[2], 'Downloading up to 4 resources at a time', verboseLines[2])
     st.equal(verboseLines[3], '', verboseLines[3])

--- a/spec/tests/info.js
+++ b/spec/tests/info.js
@@ -1,5 +1,5 @@
 import { test } from 'tape'
-import { run, asAdmin } from '../test.js'
+import { run, asAdmin, testServer } from '../test.js'
 
 test("calling 'xst info'", async (t) => {
   const { stderr, stdout } = await run('xst', ['info'])
@@ -16,7 +16,7 @@ test("calling 'xst info'", async (t) => {
 test("calling 'xst info --verbose'", async (t) => {
   const { stderr, stdout } = await run('xst', ['info', '--verbose'])
   t.plan(5)
-  t.equal(stderr, 'Connecting to https://localhost:8443 as guest\n', 'connection and user output on stderr')
+  t.equal(stderr, `Connecting to ${testServer} as guest\n`, 'connection and user output on stderr')
 
   const lines = stdout.split('\n')
   t.equal(lines.length, 4, 'outputs four lines')

--- a/spec/tests/package/install/registry.js
+++ b/spec/tests/package/install/registry.js
@@ -1,6 +1,8 @@
 import { readFile } from 'node:fs/promises'
 import test from 'tape'
-import { run, asAdmin } from '../../../test.js'
+import { run, asAdmin, testHttpServer } from '../../../test.js'
+
+const publicRepo = `${testHttpServer}/exist/apps/public-repo`
 
 const testAppName = 'http://exist-db.org/apps/test-app'
 const testLibName = 'http://exist-db.org/apps/test-lib'
@@ -33,8 +35,13 @@ async function cleanup (t) {
 }
 
 async function isLocalRepoAvailable () {
-  const { status } = await fetch('http://localhost:8080/exist/apps/public-repo')
-  return status === 200
+  try {
+    const { status } = await fetch(publicRepo)
+    return status === 200
+  } catch (_) {
+    // connection refused — no instance (or no public-repo) on this port
+    return false
+  }
 }
 
 /**
@@ -49,9 +56,8 @@ async function installPackageToLocalRepo (t) {
     formData.append('files[]', blob, app)
     formData.append('', '\\')
 
-    // TODO: Read in localhost
     const { status } = await fetch(
-      'http://localhost:8080/exist/apps/public-repo/publish',
+      `${publicRepo}/publish`,
       {
         method: 'post',
         headers: {
@@ -122,7 +128,7 @@ test('Work with a local public registry', async function (t) {
       'install',
       'registry',
       '--registry',
-      'http://localhost:8080/exist/apps/public-repo',
+      publicRepo,
       testAppName
     ])
     st.equal(
@@ -145,7 +151,7 @@ test('Work with a local public registry', async function (t) {
           'install',
           'registry',
           '--registry',
-          'http://localhost:8080/exist/apps/public-repo',
+          publicRepo,
           testAppName
         ],
         asAdmin
@@ -173,7 +179,7 @@ test('Work with a local public registry', async function (t) {
           'install',
           'registry',
           '--registry',
-          'http://localhost:8080/exist/apps/public-repo',
+          publicRepo,
           'test-app'
         ],
         asAdmin
@@ -222,7 +228,7 @@ test('Work with a local public registry', async function (t) {
           'install',
           'registry',
           '--registry',
-          'http://localhost:8080/exist/apps/public-repo',
+          publicRepo,
           testAppName,
           '1.0.1'
         ],
@@ -248,7 +254,7 @@ test('Work with a local public registry', async function (t) {
         'install',
         'registry',
         '--registry',
-        'http://localhost:8080/exist/apps/public-repo',
+        publicRepo,
         testAppName,
         '1.0.1',
         '--force'
@@ -279,7 +285,7 @@ test('Work with a local public registry', async function (t) {
           'install',
           'registry',
           '--registry',
-          'http://localhost:8080/exist/apps/public-repo',
+          publicRepo,
           testAppName,
           '10.98.2'
         ],
@@ -308,7 +314,7 @@ test('Work with a local public registry', async function (t) {
           'install',
           'registry',
           '--registry',
-          'http://localhost:8080/doesnotexist/',
+          `${testHttpServer}/doesnotexist/`,
           testAppName
         ],
         asAdmin
@@ -319,7 +325,7 @@ test('Work with a local public registry', async function (t) {
       // @todo: maybe a better error here? Explain user what actually went wrong?
       st.equal(
         stderr,
-        '✘ http://exist-db.org/apps/test-app > Server responded with a Servlet error. Probably a wrong path to the public-repo or public-repo not installed. Please check the URL http://localhost:8080/doesnotexist/\n',
+        `✘ http://exist-db.org/apps/test-app > Server responded with a Servlet error. Probably a wrong path to the public-repo or public-repo not installed. Please check the URL ${testHttpServer}/doesnotexist/\n`,
         stderr
       )
       st.end()

--- a/spec/tests/package/list.js
+++ b/spec/tests/package/list.js
@@ -1,5 +1,5 @@
 import { test } from 'tape'
-import { run, asAdmin } from '../../test.js'
+import { run, asAdmin, testServer } from '../../test.js'
 
 const testAppName = 'http://exist-db.org/apps/test-app'
 const testLibName = 'http://exist-db.org/apps/test-lib'
@@ -86,7 +86,7 @@ test.skip('sorts by type and installation date', async function (t) {
 
   if (stderr) { return t.fail(stderr) }
   const lines = stdout.split('\n')
-  t.equal(lines[0], 'Install test-app.xar on https://localhost:8443')
+  t.equal(lines[0], `Install test-app.xar on ${testServer}`)
 })
 
 test('with new package', async function (t) {

--- a/spec/tests/upload.js
+++ b/spec/tests/upload.js
@@ -1,5 +1,5 @@
 import { test } from 'tape'
-import { run, asAdmin } from '../test.js'
+import { run, asAdmin, testServer } from '../test.js'
 
 const testCollection = '/db/upload-test'
 
@@ -41,7 +41,7 @@ test('uploading files and folders', function (t) {
     const { stderr, stdout, code } = await run('xst', ['up', '-v', 'spec/test.js', testCollection])
     st.equal(code, 1, 'exit code 1')
     const lines = stderr.split('\n')
-    st.equal(lines[0], 'Connecting to https://localhost:8443 as guest', lines[0])
+    st.equal(lines[0], `Connecting to ${testServer} as guest`, lines[0])
     st.equal(lines[1], '✘ test.js Error: Write permission is not granted on the Collection.', lines[1])
     st.ok(/Upload of .+?spec\/test\.js failed\./.test(lines[2]), lines[2])
     st.ok(stdout, 'additional info is displayed')
@@ -72,7 +72,7 @@ test('uploading files and folders', function (t) {
     const { stderr, stdout, code } = await run('xst', ['up', '-v', 'spec/fixtures/test.xq', testCollection])
     st.equal(code, 1, 'exit code 1')
     const lines = stderr.split('\n')
-    st.equal(lines[0], 'Connecting to https://localhost:8443 as guest', lines[0])
+    st.equal(lines[0], `Connecting to ${testServer} as guest`, lines[0])
     st.equal(lines[1], '✘ test.xq Error: A resource with the same name already exists in the target collection \'/db/upload-test\', and you do not have write access on that resource.')
     st.ok(/Upload of .+?spec\/fixtures\/test\.xq failed\./.test(lines[2]))
     st.ok(stdout, 'additional info is displayed')

--- a/spec/tests/utility/db-path.js
+++ b/spec/tests/utility/db-path.js
@@ -1,0 +1,54 @@
+import { test } from 'tape'
+import { assertAbsoluteDbPath, normalizeDbPath } from '../../../utility/db-path.js'
+
+test('assertAbsoluteDbPath', function (t) {
+  t.test('accepts absolute paths', function (st) {
+    st.equals(assertAbsoluteDbPath('/db'), '/db')
+    st.equals(assertAbsoluteDbPath('/'), '/')
+    st.equals(assertAbsoluteDbPath('/db/apps/'), '/db/apps/')
+    st.end()
+  })
+
+  t.test('rejects relative paths with a hint', function (st) {
+    st.throws(
+      () => assertAbsoluteDbPath('my/collection'),
+      /Did you mean "\/db\/my\/collection"\?/,
+      'plain relative path hints /db prefix')
+    st.throws(
+      () => assertAbsoluteDbPath('db/apps'),
+      /Did you mean "\/db\/apps"\?/,
+      'path starting with db/ hints leading slash only')
+    st.throws(
+      () => assertAbsoluteDbPath('db'),
+      /Did you mean "\/db"\?/,
+      'bare db hints /db')
+    st.end()
+  })
+
+  t.test('rejects empty and non-string values', function (st) {
+    st.throws(() => assertAbsoluteDbPath(''), /non-empty/)
+    st.throws(() => assertAbsoluteDbPath(undefined), /non-empty/)
+    st.throws(() => assertAbsoluteDbPath(null), /non-empty/)
+    st.end()
+  })
+})
+
+test('normalizeDbPath', function (t) {
+  t.test('resolves / to /db', function (st) {
+    st.equals(normalizeDbPath('/'), '/db')
+    st.end()
+  })
+
+  t.test('strips trailing slashes', function (st) {
+    st.equals(normalizeDbPath('/db/'), '/db')
+    st.equals(normalizeDbPath('/db/apps///'), '/db/apps')
+    st.equals(normalizeDbPath('//'), '/db')
+    st.end()
+  })
+
+  t.test('leaves canonical paths untouched', function (st) {
+    st.equals(normalizeDbPath('/db'), '/db')
+    st.equals(normalizeDbPath('/db/apps'), '/db/apps')
+    st.end()
+  })
+})

--- a/utility/db-path.js
+++ b/utility/db-path.js
@@ -1,0 +1,45 @@
+/**
+ * Shared handling of database collection and resource paths.
+ *
+ * Semantics:
+ * - database paths must be absolute (leading slash)
+ * - "/" is an alias for "/db", the root collection
+ * - trailing slashes are ignored
+ */
+
+/**
+ * Ensure a database path is absolute.
+ * Throws with a helpful hint otherwise.
+ * @param {String} path database path
+ * @returns {String} the path, unchanged
+ */
+export function assertAbsoluteDbPath (path) {
+  if (typeof path !== 'string' || path === '') {
+    throw Error('Invalid path: database paths must be non-empty strings.')
+  }
+  if (!path.startsWith('/')) {
+    const hint = path === 'db' || path.startsWith('db/')
+      ? '/' + path
+      : '/db/' + path
+    throw Error(
+      `Invalid path "${path}": database paths must be absolute. Did you mean "${hint}"?`)
+  }
+  return path
+}
+
+/**
+ * Canonicalize an absolute database path.
+ * Strips trailing slashes, resolves "/" to "/db".
+ * @param {String} path absolute database path
+ * @returns {String} normalized path
+ */
+export function normalizeDbPath (path) {
+  let normalized = path
+  while (normalized.length > 1 && normalized.endsWith('/')) {
+    normalized = normalized.substring(0, normalized.length - 1)
+  }
+  if (normalized === '/') {
+    return '/db'
+  }
+  return normalized
+}

--- a/utility/options.js
+++ b/utility/options.js
@@ -1,0 +1,17 @@
+/**
+ * shared yargs option helpers
+ */
+
+/**
+ * Option definition mixin for repeatable, comma-separated string list
+ * options (e.g. --include, --exclude).
+ * The single value "false" yields the match-all pattern ['**'].
+ */
+export const stringList = {
+  type: 'string',
+  array: true,
+  coerce: (values) =>
+    values.length === 1 && values[0].trim() === 'false'
+      ? ['**']
+      : values.reduce((values, value) => values.concat(value.split(',').map((value) => value.trim())), [])
+}


### PR DESCRIPTION
# Feature

When running any XQuery with `xst run --stats ...` then the CLI will return compilation and execution time as additional information on **stderr**.
This way you can still capture the result in a file for instance while seeing the metadata directly as output.

**Example:**

```fish
; xst run -s 'for $s in (1 to 1000) return util:uuid($s)' --config spec/fixtures/.env --verbose 2&1 > result.txt
Connecting to http://localhost:8080 as admin
compilation: 5ms
execution:   13ms
```

## Summary
- `xst execute --stats` reports how long the server took to compile and to execute the query, in addition to the query result. Both timings are measured on the server by a wrapper query (`modules/exec-stats.xq`): compilation is an isolated `util:compile-query` pass, execution is the time `util:eval` takes (which includes an internal recompilation, since eXist-db offers no way to evaluate an already compiled query separately). Network transport is never part of the numbers.
- Stats go to standard error; the query result reaches standard output through the exact same code path as without the option, so piped output stays clean and byte-identical.
- Variable bindings (`-b`) work with `--stats`; binding a variable named `query` conflicts with the option and is rejected. An invalid query still reports the original compile error.
- Readme documents the option with an example.

Closes #224

The first seven commits are the shared test-infra base (suite worktree-safe and server-configurable, `db-path`/`stringList` helpers) also carried by #382, #391 and #394; they drop out of this PR once any of those lands. The last commit builds a fresh yargs parser per parse in the exec spec — a reused instance drops the positional next to a boolean option, which this PR's `--stats` test is the first to combine.

## Test plan
- [x] `npm test` (standard + full tape suite, 415/415) against an isolated `existdb/existdb:release` instance on Node 24.10.0
- [x] New specs in `spec/tests/exec.js`: option parsing, timings on stderr, nothing on stderr without the option, identical stdout with and without `--stats`, works with `-b` bindings, compile error passthrough, `query` binding conflict
- [ ] CI matrix confirms `util:compile-query` / `util:eval` behave the same on eXist 4.10, 5.4 and 6.4 (the local run covered `release` only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DdRCqwxEhrKX2uQDL1Ahsy